### PR TITLE
Melhorias nos resultados e coletas

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,13 +220,11 @@ search:
     date:
       selector: date
       filters:
-        # Corrige data inválida que vem da API
         - name: re_replace
           args: ["^(0001-01-01.*|null|)$", "now"]
         - name: dateparse
           args: "2006-01-02T15:04:05Z"
 
-    # Tamanho - usa exatamente o que vem da API ou 1 GB se for vazio/0 B
     size:
       selector: size
       optional: true
@@ -237,14 +235,12 @@ search:
     seeders:
       selector: seed_count
       filters:
-        # Garante valores válidos para seeders
         - name: re_replace
           args: ["^(|null|0)$", "1"]
 
     leechers:
       selector: leech_count
       filters:
-        # Garante valores válidos para leechers - se for 0 vira 1
         - name: re_replace
           args: ["^(|null|0)$", "1"]
 
@@ -263,7 +259,6 @@ search:
       selector: year
       optional: true
 
-    # Detecção robusta de categoria
     category_is_tv_show:
       text: "{{ .Result.title }} {{ .Result.original_title }}"
       filters:
@@ -273,7 +268,6 @@ search:
     category:
       text: "{{ if .Result.category_is_tv_show }}5000{{ else }}2000{{ end }}"
 
-    # Detecção de qualidade
     quality:
       text: "{{ .Result.title }}"
       filters:
@@ -283,7 +277,6 @@ search:
         - name: re_replace
           args: ["^$", "WEB-DL"]
 
-    # Detecção de codec
     codec:
       text: "{{ .Result.title }}"
       optional: true
@@ -292,7 +285,6 @@ search:
           args: "(?i)(x265|HEVC|H\\.?265|x264|H\\.?264|AVC|XviD|DivX)"
         - name: toupper
 
-    # Detecção de idioma/áudio
     language:
       text: "{{ .Result.title }} {{ .Result.original_title }}"
       filters:
@@ -307,7 +299,6 @@ search:
         - name: re_replace
           args: ["^$", "PT-BR"]
 
-    # Similaridade da API para debugging
     similarity:
       selector: similarity
       optional: true

--- a/README.md
+++ b/README.md
@@ -124,30 +124,29 @@ You can integrate this indexer with Prowlarr by adding a custom definition. See 
 
 ```yaml
 ---
-id: torrent-indexer
-name: Torrent Indexer
-description: "Indexing Brazilian Torrent websites into structured data. github.com/felipemarinho97/torrent-indexer"
+id: torrent-indexer-robust
+name: Brazilian Torrent Indexer (Robust)
+description: "Robust indexing of Brazilian Torrent sites via torrent-indexer API"
 language: pt-BR
 type: public
 encoding: UTF-8
 links:
-  - http://localhost:8080/
+  - http://0.0.0.0:8080/
 
 caps:
-  categories:
-    Movies: Movies
-    TV: TV
-
+  categorymappings:
+    - {id: 2000, cat: Movies, desc: "Movies"}
+    - {id: 5000, cat: TV, desc: "TV"}
   modes:
     search: [q]
-    tv-search: [q, season]
-    movie-search: [q]
+    tv-search: [q, season, ep]
+    movie-search: [q, year]
 
 settings:
   - name: indexer
     type: select
     label: Indexer
-    default: bludv
+    default: starck-filmes
     options:
       bludv: BLUDV
       comando_torrents: Comando Torrents
@@ -155,55 +154,185 @@ settings:
       comandohds: Comando HDs
       starck-filmes: Starck Filmes
       rede_torrent: Rede Torrent
+  - name: timeout
+    type: text
+    label: Timeout (seconds)
+    default: "30"
+  - name: filter_results
+    type: checkbox
+    label: Filter similar results
+    default: true
 
 search:
   paths:
     - path: "/indexers/{{ .Config.indexer }}"
+      method: get
       response:
         type: json
+      
   inputs:
-    filter_results: "true"
     q: "{{ .Keywords }}"
+    filter_results: "{{ if .Config.filter_results }}true{{ else }}false{{ end }}"
+    timeout: "{{ .Config.timeout }}"
+
   keywordsfilters:
     - name: tolower
     - name: re_replace
-      args: ["(?i)(S0)(\\d{1,2})$", "temporada $2"]
+      args: ["(?i)\\bS0?(\\d{1,2})E\\d{2}\\b", "temporada $1"]
     - name: re_replace
-      args: ["(?i)(S)(\\d{1,3})$", "temporada $2"]
+      args: ["(?i)\\bS0?(\\d{1,2})\\b$", "temporada $1"]
+    - name: re_replace
+      args: ["\\s+", " "]
+    - name: trim
 
   rows:
-    selector: $.results
+    selector: "$.results"
     count:
-      selector: $.count
+      selector: "$.count"
 
   fields:
-    download:
-      selector: magnet_link
     title:
       selector: title
-    description:
+      filters:
+        - name: re_replace
+          args: ["[\\n\\r]+", " "]
+        - name: re_replace
+          args: ["\\s{2,}", " "]
+        - name: trim
+
+    original_title:
       selector: original_title
+      optional: true
+
+    description:
+      text: "{{ if .Result.original_title }}{{ .Result.original_title }}{{ else }}{{ .Result.title }}{{ end }}"
+
     details:
       selector: details
-    infohash:
-      selector: info_hash
+      filters:
+        - name: urldecode
+
+    download:
+      selector: magnet_link
+      filters:
+        - name: urldecode
+
     date:
       selector: date
+      filters:
+        # Corrige data inválida que vem da API
+        - name: re_replace
+          args: ["^(0001-01-01.*|null|)$", "now"]
+        - name: dateparse
+          args: "2006-01-02T15:04:05Z"
+
+    # Tamanho - usa exatamente o que vem da API ou 1 GB se for vazio/0 B
     size:
       selector: size
+      optional: true
+      filters:
+        - name: re_replace
+          args: ["^(|0 B|0B)$", "1 GB"]
+
     seeders:
       selector: seed_count
+      filters:
+        # Garante valores válidos para seeders
+        - name: re_replace
+          args: ["^(|null|0)$", "1"]
+
     leechers:
       selector: leech_count
-    imdb:
+      filters:
+        # Garante valores válidos para leechers - se for 0 vira 1
+        - name: re_replace
+          args: ["^(|null|0)$", "1"]
+
+    infohash:
+      selector: info_hash
+      optional: true
+
+    imdbid:
       selector: imdb
+      optional: true
+      filters:
+        - name: re_replace
+          args: ["^$", ""]
+
+    year:
+      selector: year
+      optional: true
+
+    # Detecção robusta de categoria
     category_is_tv_show:
-      selector: title
+      text: "{{ .Result.title }} {{ .Result.original_title }}"
       filters:
         - name: regexp
-          args: "\\b(S\\d+(?:E\\d+)?)\\b"
+          args: "(?i)(temporada|season|S\\d{1,3}E\\d{1,3}|S\\d{1,3}$|\\d+x\\d+|série|series|episódio|episode|EP\\d+|1ª|2ª|3ª|4ª|5ª|6ª|7ª|8ª|9ª|10ª|completa)"
+
     category:
-      text: "{{ if .Result.category_is_tv_show }}TV{{ else }}Movies{{ end }}"
+      text: "{{ if .Result.category_is_tv_show }}5000{{ else }}2000{{ end }}"
+
+    # Detecção de qualidade
+    quality:
+      text: "{{ .Result.title }}"
+      filters:
+        - name: regexp
+          args: "(?i)(2160p|4K|UHD|1080p|FHD|FullHD|720p|HD|480p|SD|BluRay|BRRip|WEB-?DL|WEBRip|HDTV|DVDRip)"
+        - name: toupper
+        - name: re_replace
+          args: ["^$", "WEB-DL"]
+
+    # Detecção de codec
+    codec:
+      text: "{{ .Result.title }}"
+      optional: true
+      filters:
+        - name: regexp
+          args: "(?i)(x265|HEVC|H\\.?265|x264|H\\.?264|AVC|XviD|DivX)"
+        - name: toupper
+
+    # Detecção de idioma/áudio
+    language:
+      text: "{{ .Result.title }} {{ .Result.original_title }}"
+      filters:
+        - name: regexp
+          args: "(?i)(DUAL|Dublado|Legendado|Nacional|PT-?BR|Português|Inglês)"
+        - name: re_replace
+          args: ["(?i)dual", "Dual Áudio"]
+        - name: re_replace
+          args: ["(?i)(dublado|nacional)", "Dublado"]
+        - name: re_replace
+          args: ["(?i)legendado", "Legendado"]
+        - name: re_replace
+          args: ["^$", "PT-BR"]
+
+    # Similaridade da API para debugging
+    similarity:
+      selector: similarity
+      optional: true
+
+retry:
+  count: 3
+  delay: 2
+
+error:
+  - selector: "$.error"
+    message:
+      selector: "$.message"
+      
+  - selector: "$.results"
+    filter:
+      selector: "."
+      filters:
+        - name: regexp
+          args: "^\\[\\]$"
+    message:
+      text: "Nenhum resultado encontrado para este indexer. Tente outro ou ajuste a busca."
+
+  - selector: ":contains(\"timeout\")"
+    message:
+      text: "Timeout na requisição. Aumente o timeout nas configurações ou tente novamente."
 ```
 
 # Warning

--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ language: pt-BR
 type: public
 encoding: UTF-8
 links:
-  - http://0.0.0.0:8080/
+  - http://localhost:8080/
 
 caps:
   categorymappings:

--- a/api/rede_torrent.go
+++ b/api/rede_torrent.go
@@ -25,6 +25,107 @@ var rede_torrent = IndexerMeta{
 	PagePattern: "%s",
 }
 
+func createStandardizedTitleRT(originalTitle, year, releaseTitle string) string {
+	if originalTitle == "" {
+		return releaseTitle
+	}
+	
+	cleanOriginalTitle := strings.ReplaceAll(originalTitle, " ", ".")
+	cleanOriginalTitle = regexp.MustCompile(`[^\w\.\-]`).ReplaceAllString(cleanOriginalTitle, "")
+	
+	yearRegex := regexp.MustCompile(`(19|20)\d{2}`)
+	seasonRegex := regexp.MustCompile(`(?i)s\d{1,2}e?\d{0,2}`)
+	
+	if yearMatch := yearRegex.FindStringIndex(releaseTitle); yearMatch != nil {
+		beforeYear := releaseTitle[:yearMatch[0]]
+		fromYear := releaseTitle[yearMatch[0]:]
+		
+		beforeYear = strings.TrimRight(beforeYear, ". ")
+		if beforeYear != "" {
+			return cleanOriginalTitle + "." + fromYear
+		} else {
+			return cleanOriginalTitle + "." + fromYear
+		}
+	}
+	
+	if seasonMatch := seasonRegex.FindStringIndex(releaseTitle); seasonMatch != nil {
+		beforeSeason := releaseTitle[:seasonMatch[0]]
+		fromSeason := releaseTitle[seasonMatch[0]:]
+		
+		beforeSeason = strings.TrimRight(beforeSeason, ". ")
+		if beforeSeason != "" {
+			return cleanOriginalTitle + "." + fromSeason
+		} else {
+			return cleanOriginalTitle + "." + fromSeason
+		}
+	}
+	
+	return releaseTitle
+}
+
+func (i *Indexer) trySearchVariationsRT(ctx context.Context, baseURL, searchURL, query string) ([]string, error) {
+	if query == "" {
+		return nil, nil
+	}
+	
+	variations := []string{
+		query,
+	}
+	
+	firstWord := strings.Split(query, " ")[0]
+	if !strings.HasPrefix(strings.ToLower(query), "the ") {
+		variations = append(variations, "The "+firstWord)
+	}
+	
+	if firstWord != query {
+		variations = append(variations, firstWord)
+	}
+	
+	var allLinks []string
+	
+	for _, variation := range variations {
+		encodedQuery := url.QueryEscape(variation)
+		searchURL := baseURL + searchURL + encodedQuery
+		
+		resp, err := i.requester.GetDocument(ctx, searchURL)
+		if err != nil {
+			continue
+		}
+		
+		doc, err := goquery.NewDocumentFromReader(resp)
+		resp.Close()
+		if err != nil {
+			continue
+		}
+		
+		var variationLinks []string
+		doc.Find(".capa_lista").Each(func(j int, s *goquery.Selection) {
+			link, exists := s.Find("a").Attr("href")
+			if exists && link != "" {
+				variationLinks = append(variationLinks, link)
+			}
+		})
+		
+		allLinks = append(allLinks, variationLinks...)
+	}
+	
+	uniqueLinks := removeDuplicatesRT(allLinks)
+	return uniqueLinks, nil
+}
+
+func removeDuplicatesRT(links []string) []string {
+	keys := make(map[string]bool)
+	var result []string
+	
+	for _, link := range links {
+		if !keys[link] && link != "" {
+			keys[link] = true
+			result = append(result, link)
+		}
+	}
+	return result
+}
+
 func (i *Indexer) HandlerRedeTorrentIndexer(w http.ResponseWriter, r *http.Request) {
 	start := time.Now()
 	metadata := rede_torrent
@@ -35,56 +136,64 @@ func (i *Indexer) HandlerRedeTorrentIndexer(w http.ResponseWriter, r *http.Reque
 	}()
 
 	ctx := r.Context()
-	// supported query params: q, season, episode, page, filter_results
 	q := r.URL.Query().Get("q")
 	page := r.URL.Query().Get("page")
 
-	// URL encode query param
-	q = url.QueryEscape(q)
-	url := metadata.URL
-	if q != "" {
-		url = fmt.Sprintf("%s%s%s", url, metadata.SearchURL, q)
-	} else if page != "" {
-		url = fmt.Sprintf(fmt.Sprintf("%s%s", url, metadata.PagePattern), page)
-	}
-
-	fmt.Println("URL:>", url)
-	resp, err := i.requester.GetDocument(ctx, url)
-	if err != nil {
-		w.WriteHeader(http.StatusInternalServerError)
-		err = json.NewEncoder(w).Encode(map[string]string{"error": err.Error()})
-		if err != nil {
-			fmt.Println(err)
-		}
-		i.metrics.IndexerErrors.WithLabelValues(metadata.Label).Inc()
-		return
-	}
-	defer resp.Close()
-
-	doc, err := goquery.NewDocumentFromReader(resp)
-	if err != nil {
-		w.WriteHeader(http.StatusInternalServerError)
-		err = json.NewEncoder(w).Encode(map[string]string{"error": err.Error()})
-		if err != nil {
-			fmt.Println(err)
-		}
-
-		i.metrics.IndexerErrors.WithLabelValues(metadata.Label).Inc()
-		return
-	}
-
 	var links []string
-	doc.Find(".capa_lista").Each(func(i int, s *goquery.Selection) {
-		link, _ := s.Find("a").Attr("href")
-		links = append(links, link)
-	})
+	var err error
 
-	// extract each torrent link
+	if q != "" {
+		links, err = i.trySearchVariationsRT(ctx, metadata.URL, metadata.SearchURL, q)
+		if err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			err = json.NewEncoder(w).Encode(map[string]string{"error": err.Error()})
+			if err != nil {
+				fmt.Println(err)
+			}
+			i.metrics.IndexerErrors.WithLabelValues(metadata.Label).Inc()
+			return
+		}
+	} else {
+		url := metadata.URL
+		if page != "" {
+			url = fmt.Sprintf(fmt.Sprintf("%s%s", url, metadata.PagePattern), page)
+		}
+
+		resp, err := i.requester.GetDocument(ctx, url)
+		if err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			err = json.NewEncoder(w).Encode(map[string]string{"error": err.Error()})
+			if err != nil {
+				fmt.Println(err)
+			}
+			i.metrics.IndexerErrors.WithLabelValues(metadata.Label).Inc()
+			return
+		}
+		defer resp.Close()
+
+		doc, err := goquery.NewDocumentFromReader(resp)
+		if err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			err = json.NewEncoder(w).Encode(map[string]string{"error": err.Error()})
+			if err != nil {
+				fmt.Println(err)
+			}
+			i.metrics.IndexerErrors.WithLabelValues(metadata.Label).Inc()
+			return
+		}
+
+		doc.Find(".capa_lista").Each(func(i int, s *goquery.Selection) {
+			link, _ := s.Find("a").Attr("href")
+			if link != "" {
+				links = append(links, link)
+			}
+		})
+	}
+
 	indexedTorrents := utils.ParallelFlatMap(links, func(link string) ([]schema.IndexedTorrent, error) {
 		return getTorrentsRedeTorrent(ctx, i, link)
 	})
 
-	// Apply post-processors
 	postProcessedTorrents := indexedTorrents
 	for _, processor := range i.postProcessors {
 		postProcessedTorrents = processor(i, r, postProcessedTorrents)
@@ -108,7 +217,6 @@ func getTorrentsRedeTorrent(ctx context.Context, i *Indexer, link string) ([]sch
 	}
 
 	article := doc.Find(".conteudo")
-	// title pattern: "Something - optional balbla (dddd) some shit" - extract "Something" and "dddd"
 	titleRe := regexp.MustCompile(`^(.*?)(?: - (.*?))? \((\d{4})\)`)
 	titleP := titleRe.FindStringSubmatch(article.Find("h1").Text())
 	if len(titleP) < 3 {
@@ -116,6 +224,38 @@ func getTorrentsRedeTorrent(ctx context.Context, i *Indexer, link string) ([]sch
 	}
 	title := strings.TrimSpace(titleP[1])
 	year := strings.TrimSpace(titleP[3])
+
+	var originalTitle string
+	article.Find("div#informacoes > p").Each(func(i int, s *goquery.Selection) {
+		htmlContent, err := s.Html()
+		if err != nil {
+			return
+		}
+
+		htmlContent = strings.ReplaceAll(htmlContent, "\n", "")
+		htmlContent = strings.ReplaceAll(htmlContent, "\t", "")
+
+		brRe := regexp.MustCompile(`<br\s*\/?>`)
+		htmlContent = brRe.ReplaceAllString(htmlContent, "<br>")
+		lines := strings.Split(htmlContent, "<br>")
+
+		for _, line := range lines {
+			re := regexp.MustCompile(`<[^>]*>`)
+			line = re.ReplaceAllString(line, "")
+			line = strings.TrimSpace(line)
+			
+			if strings.Contains(line, "Título Original:") {
+				parts := strings.Split(line, "Título Original:")
+				if len(parts) > 1 {
+					originalTitle = strings.TrimSpace(parts[1])
+				}
+			}
+		}
+	})
+
+	if originalTitle == "" {
+		originalTitle = title
+	}
 
 	textContent := article.Find(".apenas_itemprop")
 	date := getPublishedDateFromMeta(doc)
@@ -129,39 +269,21 @@ func getTorrentsRedeTorrent(ctx context.Context, i *Indexer, link string) ([]sch
 	var audio []schema.Audio
 	var size []string
 	article.Find("div#informacoes > p").Each(func(i int, s *goquery.Selection) {
-		// pattern:
-		// Filme Bicho de Sete Cabeças Torrent
-		// Título Original: Bicho de Sete Cabeças
-		// Lançamento: 2001
-		// Gêneros: Drama / Nacional
-		// Idioma: Português
-		// Qualidade: 720p / BluRay
-		// Duração: 1h 14 Minutos
-		// Formato: Mp4
-		// Vídeo: 10 e Áudio: 10
-		// Legendas: Português
-		// Nota do Imdb: 7.7
-		// Tamanho: 1.26 GB
-
-		// we need to manualy parse because the text is not well formatted
 		htmlContent, err := s.Html()
 		if err != nil {
 			fmt.Println(err)
 			return
 		}
 
-		// remove any \n and \t characters
 		htmlContent = strings.ReplaceAll(htmlContent, "\n", "")
 		htmlContent = strings.ReplaceAll(htmlContent, "\t", "")
 
-		// split by <br> tags and render each line
 		brRe := regexp.MustCompile(`<br\s*\/?>`)
 		htmlContent = brRe.ReplaceAllString(htmlContent, "<br>")
 		lines := strings.Split(htmlContent, "<br>")
 
 		var text strings.Builder
 		for _, line := range lines {
-			// remove any HTML tags
 			re := regexp.MustCompile(`<[^>]*>`)
 			line = re.ReplaceAllString(line, "")
 
@@ -177,7 +299,6 @@ func getTorrentsRedeTorrent(ctx context.Context, i *Indexer, link string) ([]sch
 		size = append(size, findSizesFromText(text.String())...)
 	})
 
-	// find any link from imdb
 	imdbLink := ""
 	article.Find("a").Each(func(i int, s *goquery.Selection) {
 		link, _ := s.Attr("href")
@@ -191,27 +312,47 @@ func getTorrentsRedeTorrent(ctx context.Context, i *Indexer, link string) ([]sch
 
 	var chanIndexedTorrent = make(chan schema.IndexedTorrent)
 
-	// for each magnet link, create a new indexed torrent
 	for it, magnetLink := range magnetLinks {
 		it := it
 		go func(it int, magnetLink string) {
+			magnetLink = strings.ReplaceAll(magnetLink, "&#038;", "&")
+			magnetLink = strings.ReplaceAll(magnetLink, "&amp;", "&")
+			
 			magnet, err := magnet.ParseMagnetUri(magnetLink)
 			if err != nil {
 				fmt.Println(err)
 			}
-			releaseTitle := magnet.DisplayName
+
+			originalReleaseTitle := strings.TrimSpace(magnet.DisplayName)
+			originalReleaseTitle, err = url.QueryUnescape(originalReleaseTitle)
+			if err != nil {
+				originalReleaseTitle = strings.TrimSpace(magnet.DisplayName)
+			}
+
+			standardizedTitle := createStandardizedTitleRT(originalTitle, year, originalReleaseTitle)
+
 			infoHash := magnet.InfoHash.String()
 			trackers := magnet.Trackers
-			magnetAudio := getAudioFromTitle(releaseTitle, audio)
+			for i, tracker := range trackers {
+				unescapedTracker := strings.ReplaceAll(tracker, "&#038;", "&")
+				unescapedTracker = strings.ReplaceAll(unescapedTracker, "&amp;", "&")
+				
+				unescapedTracker, err := url.QueryUnescape(unescapedTracker)
+				if err != nil {
+					fmt.Println(err)
+				}
+				trackers[i] = strings.TrimSpace(unescapedTracker)
+			}
+
+			magnetAudio := getAudioFromTitle(originalReleaseTitle, audio)
 
 			peer, seed, err := goscrape.GetLeechsAndSeeds(ctx, i.redis, i.metrics, infoHash, trackers)
 			if err != nil {
 				fmt.Println(err)
 			}
 
-			title := processTitle(title, magnetAudio)
+			processedTitle := processTitle(title, magnetAudio)
 
-			// if the number of sizes is equal to the number of magnets, then assign the size to each indexed torrent in order
 			var mySize string
 			if len(size) == len(magnetLinks) {
 				mySize = size[it]
@@ -223,8 +364,8 @@ func getTorrentsRedeTorrent(ctx context.Context, i *Indexer, link string) ([]sch
 			}
 
 			ixt := schema.IndexedTorrent{
-				Title:         releaseTitle,
-				OriginalTitle: title,
+				Title:         standardizedTitle,
+				OriginalTitle: processedTitle,
 				Details:       link,
 				Year:          year,
 				IMDB:          imdbLink,

--- a/api/starck_filmes.go
+++ b/api/starck_filmes.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"regexp"
 	"strings"
 	"time"
 
@@ -17,11 +18,161 @@ import (
 	"github.com/felipemarinho97/torrent-indexer/utils"
 )
 
+type Requester struct {
+}
+
+func (r *Requester) GetDocument(ctx context.Context, url string) (resp *strings.Reader, err error) {
+	return nil, nil
+}
+
+func (r *Requester) ExpireDocument(ctx context.Context, url string) error {
+	fmt.Println("ExpireDocument chamado para:", url)
+	return nil
+}
+
 var starck_filmes = IndexerMeta{
 	Label:       "starck_filmes",
-	URL:         "https://www.starckfilmes.online/",
+	URL:         "https://www.starckfilmes.fans/",
 	SearchURL:   "?s=",
 	PagePattern: "page/%s",
+}
+
+// Função para remover duplicatas
+func removeDuplicates(links []string) []string {
+	keys := make(map[string]bool)
+	var result []string
+	
+	for _, link := range links {
+		if !keys[link] && link != "" {
+			keys[link] = true
+			result = append(result, link)
+		}
+	}
+	return result
+}
+
+// Função para fazer busca com variações do termo
+func (i *Indexer) trySearchVariations(ctx context.Context, baseURL, searchURL, query string) ([]string, error) {
+	if query == "" {
+		return nil, nil
+	}
+	
+	// Cria variações do termo de busca
+	variations := []string{
+		query, // "Amateur 2025"
+	}
+	
+	// Adiciona variação com "The" se não começar com "The"
+	firstWord := strings.Split(query, " ")[0]
+	if !strings.HasPrefix(strings.ToLower(query), "the ") {
+		variations = append(variations, "The "+firstWord)
+	}
+	
+	// Adiciona apenas o primeiro termo (sem ano)
+	if firstWord != query {
+		variations = append(variations, firstWord)
+	}
+	
+	fmt.Printf("Tentando variações de busca: %v\n", variations)
+	
+	var allLinks []string
+	
+	for _, variation := range variations {
+		fmt.Printf("Buscando por: %s\n", variation)
+		
+		encodedQuery := url.QueryEscape(variation)
+		searchURL := baseURL + searchURL + encodedQuery
+		
+		fmt.Printf("URL de busca: %s\n", searchURL)
+		
+		// Faz a requisição
+		resp, err := i.requester.GetDocument(ctx, searchURL)
+		if err != nil {
+			fmt.Printf("Erro na busca por '%s': %v\n", variation, err)
+			continue
+		}
+		
+		doc, err := goquery.NewDocumentFromReader(resp)
+		resp.Close()
+		if err != nil {
+			fmt.Printf("Erro ao parsear HTML para '%s': %v\n", variation, err)
+			continue
+		}
+		
+		// Extrai os links desta variação
+		var variationLinks []string
+		doc.Find(".item").Each(func(j int, s *goquery.Selection) {
+			link, exists := s.Find("div.sub-item > a").Attr("href")
+			if exists && link != "" {
+				variationLinks = append(variationLinks, link)
+			}
+		})
+		
+		fmt.Printf("Encontrados %d resultados para '%s'\n", len(variationLinks), variation)
+		allLinks = append(allLinks, variationLinks...)
+		
+		// Se encontrou resultados na primeira variação, pode parar (opcional)
+		// if len(variationLinks) > 0 {
+		//     break
+		// }
+	}
+	
+	// Remove duplicatas
+	uniqueLinks := removeDuplicates(allLinks)
+	fmt.Printf("Total único de links encontrados: %d\n", len(uniqueLinks))
+	
+	return uniqueLinks, nil
+}
+
+// Função para criar título padronizado substituindo apenas o início
+func createStandardizedTitle(originalTitle, year, releaseTitle string) string {
+	// Se não tiver originalTitle, retorna o magnet original
+	if originalTitle == "" {
+		return releaseTitle
+	}
+	
+	// Limpa o título original (remove caracteres especiais, substitui espaços por pontos)
+	cleanOriginalTitle := strings.ReplaceAll(originalTitle, " ", ".")
+	cleanOriginalTitle = regexp.MustCompile(`[^\w\.\-]`).ReplaceAllString(cleanOriginalTitle, "")
+	
+	// Regex para encontrar ano (4 dígitos)
+	yearRegex := regexp.MustCompile(`(19|20)\d{2}`)
+	
+	// Regex para encontrar temporada (SxxExx ou SxxE padrão)
+	seasonRegex := regexp.MustCompile(`(?i)s\d{1,2}e?\d{0,2}`)
+	
+	// Procura por ano primeiro
+	if yearMatch := yearRegex.FindStringIndex(releaseTitle); yearMatch != nil {
+		// Encontrou ano - substitui tudo antes do ano
+		beforeYear := releaseTitle[:yearMatch[0]]
+		fromYear := releaseTitle[yearMatch[0]:]
+		
+		// Remove pontos/espaços extras no final do início
+		beforeYear = strings.TrimRight(beforeYear, ". ")
+		if beforeYear != "" {
+			return cleanOriginalTitle + "." + fromYear
+		} else {
+			return cleanOriginalTitle + "." + fromYear
+		}
+	}
+	
+	// Se não encontrou ano, procura por temporada
+	if seasonMatch := seasonRegex.FindStringIndex(releaseTitle); seasonMatch != nil {
+		// Encontrou temporada - substitui tudo antes da temporada
+		beforeSeason := releaseTitle[:seasonMatch[0]]
+		fromSeason := releaseTitle[seasonMatch[0]:]
+		
+		// Remove pontos/espaços extras no final do início
+		beforeSeason = strings.TrimRight(beforeSeason, ". ")
+		if beforeSeason != "" {
+			return cleanOriginalTitle + "." + fromSeason
+		} else {
+			return cleanOriginalTitle + "." + fromSeason
+		}
+	}
+	
+	// Se não encontrou nem ano nem temporada, retorna o magnet original
+	return releaseTitle
 }
 
 func (i *Indexer) HandlerStarckFilmesIndexer(w http.ResponseWriter, r *http.Request) {
@@ -34,73 +185,75 @@ func (i *Indexer) HandlerStarckFilmesIndexer(w http.ResponseWriter, r *http.Requ
 	}()
 
 	ctx := r.Context()
-	// supported query params: q, page, filter_results
 	q := r.URL.Query().Get("q")
 	page := r.URL.Query().Get("page")
 
-	// URL encode query param
-	q = url.QueryEscape(q)
-	url := metadata.URL
-	if q != "" {
-		url = fmt.Sprintf("%s%s%s", url, metadata.SearchURL, q)
-	} else if page != "" {
-		url = fmt.Sprintf(fmt.Sprintf("%s%s", url, metadata.PagePattern), page)
-	}
-
-	fmt.Println("URL:>", url)
-	resp, err := i.requester.GetDocument(ctx, url)
-	if err != nil {
-		w.WriteHeader(http.StatusInternalServerError)
-		err = json.NewEncoder(w).Encode(map[string]string{"error": err.Error()})
-		if err != nil {
-			fmt.Println(err)
-		}
-		i.metrics.IndexerErrors.WithLabelValues(metadata.Label).Inc()
-		return
-	}
-	defer resp.Close()
-
-	doc, err := goquery.NewDocumentFromReader(resp)
-	if err != nil {
-		w.WriteHeader(http.StatusInternalServerError)
-		err = json.NewEncoder(w).Encode(map[string]string{"error": err.Error()})
-		if err != nil {
-			fmt.Println(err)
-		}
-
-		i.metrics.IndexerErrors.WithLabelValues(metadata.Label).Inc()
-		return
-	}
-
 	var links []string
-	doc.Find(".item").Each(func(i int, s *goquery.Selection) {
-		link, _ := s.Find("div.sub-item > a").Attr("href")
-		links = append(links, link)
-	})
+	var err error
 
-	// extract each torrent link
+	if q != "" {
+		// Usa a nova função de busca com variações
+		links, err = i.trySearchVariations(ctx, metadata.URL, metadata.SearchURL, q)
+		if err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			_ = json.NewEncoder(w).Encode(map[string]string{"error": err.Error()})
+			i.metrics.IndexerErrors.WithLabelValues(metadata.Label).Inc()
+			return
+		}
+	} else {
+		// Para paginação ou busca sem termo, usa a lógica original
+		urlStr := metadata.URL
+		if page != "" {
+			urlStr = fmt.Sprintf(fmt.Sprintf("%s%s", urlStr, metadata.PagePattern), page)
+		} else {
+			urlStr = fmt.Sprintf(fmt.Sprintf("%s%s", urlStr, metadata.PagePattern), "1")
+		}
+
+		fmt.Println("URL de paginação:>", urlStr)
+		resp, err := i.requester.GetDocument(ctx, urlStr)
+		if err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			_ = json.NewEncoder(w).Encode(map[string]string{"error": err.Error()})
+			i.metrics.IndexerErrors.WithLabelValues(metadata.Label).Inc()
+			return
+		}
+		defer resp.Close()
+
+		doc, err := goquery.NewDocumentFromReader(resp)
+		if err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			_ = json.NewEncoder(w).Encode(map[string]string{"error": err.Error()})
+			i.metrics.IndexerErrors.WithLabelValues(metadata.Label).Inc()
+			return
+		}
+
+		doc.Find(".item").Each(func(i int, s *goquery.Selection) {
+			link, _ := s.Find("div.sub-item > a").Attr("href")
+			if link != "" {
+				links = append(links, link)
+			}
+		})
+	}
+
 	indexedTorrents := utils.ParallelFlatMap(links, func(link string) ([]schema.IndexedTorrent, error) {
 		return getTorrentStarckFilmes(ctx, i, link)
 	})
 
-	// Apply post-processors
 	postProcessedTorrents := indexedTorrents
 	for _, processor := range i.postProcessors {
 		postProcessedTorrents = processor(i, r, postProcessedTorrents)
 	}
 
 	w.Header().Set("Content-Type", "application/json")
-	err = json.NewEncoder(w).Encode(Response{
+	_ = json.NewEncoder(w).Encode(Response{
 		Results: postProcessedTorrents,
 		Count:   len(postProcessedTorrents),
 	})
-	if err != nil {
-		fmt.Println(err)
-	}
 }
 
 func getTorrentStarckFilmes(ctx context.Context, i *Indexer, link string) ([]schema.IndexedTorrent, error) {
 	var indexedTorrents []schema.IndexedTorrent
+
 	doc, err := getDocument(ctx, i, link)
 	if err != nil {
 		return nil, err
@@ -110,7 +263,27 @@ func getTorrentStarckFilmes(ctx context.Context, i *Indexer, link string) ([]sch
 
 	post := doc.Find(".post")
 	capa := post.Find(".capa")
-	title := capa.Find(".post-description > h2").Text()
+
+	pageTitle := capa.Find(".post-description > h2").Text()
+
+	var originalTitle string
+	capa.Find(".post-description p").Each(func(i int, s *goquery.Selection) {
+		spans := s.Find("span")
+		spans.Each(func(j int, span *goquery.Selection) {
+			if strings.Contains(span.Text(), "Nome Original:") {
+				originalSpan := span.Next()
+				if originalSpan != nil && strings.TrimSpace(originalSpan.Text()) != "" {
+					originalTitle = strings.TrimSpace(originalSpan.Text())
+				}
+			}
+		})
+	})
+
+	// Se não encontrou o título original, usa o título da página
+	if originalTitle == "" {
+		originalTitle = pageTitle
+	}
+
 	post_buttons := post.Find(".post-buttons")
 	magnets := post_buttons.Find("a[href^=\"magnet\"]")
 	var magnetLinks []string
@@ -123,38 +296,24 @@ func getTorrentStarckFilmes(ctx context.Context, i *Indexer, link string) ([]sch
 	var year string
 	var size []string
 	capa.Find(".post-description p").Each(func(i int, s *goquery.Selection) {
-		// pattern:
-		// Nome Original: 28 Weeks Later
-		// Lançamento: 2007
-		// Duração: 1h 40 min
-		// Gênero: Terror, Suspense, Ficção
-		// Formato: MKV
-		// Tamanho: 2.45 GB
-		// Qualidade de Video: 10
-		// Qualidade do Audio: 10
-		// Idioma: Português | Inglês
-		// Legenda: Português, Inglês, Espanhol
 		var text strings.Builder
 		s.Find("span").Each(func(i int, span *goquery.Selection) {
 			text.WriteString(span.Text())
 			text.WriteString(" ")
 		})
 		audio = append(audio, findAudioFromText(text.String())...)
-		y := findYearFromText(text.String(), title)
+		y := findYearFromText(text.String(), pageTitle)
 		if y != "" {
 			year = y
 		}
 		size = append(size, findSizesFromText(text.String())...)
 	})
 
-	// TODO: find any link from imdb
 	imdbLink := ""
-
 	size = utils.StableUniq(size)
 
 	var chanIndexedTorrent = make(chan schema.IndexedTorrent)
 
-	// for each magnet link, create a new indexed torrent
 	for it, magnetLink := range magnetLinks {
 		it := it
 		go func(it int, magnetLink string) {
@@ -162,13 +321,16 @@ func getTorrentStarckFilmes(ctx context.Context, i *Indexer, link string) ([]sch
 			if err != nil {
 				fmt.Println(err)
 			}
-			releaseTitle := strings.TrimSpace(magnet.DisplayName)
-			// url decode the title
-			releaseTitle, err = url.QueryUnescape(releaseTitle)
+
+			originalReleaseTitle := strings.TrimSpace(magnet.DisplayName)
+			originalReleaseTitle, err = url.QueryUnescape(originalReleaseTitle)
 			if err != nil {
-				fmt.Println(err)
-				releaseTitle = strings.TrimSpace(magnet.DisplayName)
+				originalReleaseTitle = strings.TrimSpace(magnet.DisplayName)
 			}
+
+			// Cria o título padronizado usando a nova função
+			standardizedTitle := createStandardizedTitle(originalTitle, year, originalReleaseTitle)
+
 			infoHash := magnet.InfoHash.String()
 			trackers := magnet.Trackers
 			for i, tracker := range trackers {
@@ -178,16 +340,14 @@ func getTorrentStarckFilmes(ctx context.Context, i *Indexer, link string) ([]sch
 				}
 				trackers[i] = strings.TrimSpace(unescapedTracker)
 			}
-			magnetAudio := getAudioFromTitle(releaseTitle, audio)
+
+			magnetAudio := getAudioFromTitle(originalReleaseTitle, audio)
 
 			peer, seed, err := goscrape.GetLeechsAndSeeds(ctx, i.redis, i.metrics, infoHash, trackers)
 			if err != nil {
 				fmt.Println(err)
 			}
 
-			title := processTitle(title, magnetAudio)
-
-			// if the number of sizes is equal to the number of magnets, then assign the size to each indexed torrent in order
 			var mySize string
 			if len(size) == len(magnetLinks) {
 				mySize = size[it]
@@ -199,8 +359,8 @@ func getTorrentStarckFilmes(ctx context.Context, i *Indexer, link string) ([]sch
 			}
 
 			ixt := schema.IndexedTorrent{
-				Title:         releaseTitle,
-				OriginalTitle: title,
+				Title:         standardizedTitle, // Usa o título padronizado
+				OriginalTitle: pageTitle,
 				Details:       link,
 				Year:          year,
 				IMDB:          imdbLink,

--- a/api/starck_filmes.go
+++ b/api/starck_filmes.go
@@ -37,7 +37,6 @@ var starck_filmes = IndexerMeta{
 	PagePattern: "page/%s",
 }
 
-// Função para remover duplicatas
 func removeDuplicates(links []string) []string {
 	keys := make(map[string]bool)
 	var result []string
@@ -51,55 +50,41 @@ func removeDuplicates(links []string) []string {
 	return result
 }
 
-// Função para fazer busca com variações do termo
 func (i *Indexer) trySearchVariations(ctx context.Context, baseURL, searchURL, query string) ([]string, error) {
 	if query == "" {
 		return nil, nil
 	}
 	
-	// Cria variações do termo de busca
 	variations := []string{
-		query, // "Amateur 2025"
+		query,
 	}
 	
-	// Adiciona variação com "The" se não começar com "The"
 	firstWord := strings.Split(query, " ")[0]
 	if !strings.HasPrefix(strings.ToLower(query), "the ") {
 		variations = append(variations, "The "+firstWord)
 	}
 	
-	// Adiciona apenas o primeiro termo (sem ano)
 	if firstWord != query {
 		variations = append(variations, firstWord)
 	}
 	
-	fmt.Printf("Tentando variações de busca: %v\n", variations)
-	
 	var allLinks []string
 	
 	for _, variation := range variations {
-		fmt.Printf("Buscando por: %s\n", variation)
-		
 		encodedQuery := url.QueryEscape(variation)
 		searchURL := baseURL + searchURL + encodedQuery
 		
-		fmt.Printf("URL de busca: %s\n", searchURL)
-		
-		// Faz a requisição
 		resp, err := i.requester.GetDocument(ctx, searchURL)
 		if err != nil {
-			fmt.Printf("Erro na busca por '%s': %v\n", variation, err)
 			continue
 		}
 		
 		doc, err := goquery.NewDocumentFromReader(resp)
 		resp.Close()
 		if err != nil {
-			fmt.Printf("Erro ao parsear HTML para '%s': %v\n", variation, err)
 			continue
 		}
 		
-		// Extrai os links desta variação
 		var variationLinks []string
 		doc.Find(".item").Each(func(j int, s *goquery.Selection) {
 			link, exists := s.Find("div.sub-item > a").Attr("href")
@@ -108,46 +93,28 @@ func (i *Indexer) trySearchVariations(ctx context.Context, baseURL, searchURL, q
 			}
 		})
 		
-		fmt.Printf("Encontrados %d resultados para '%s'\n", len(variationLinks), variation)
 		allLinks = append(allLinks, variationLinks...)
-		
-		// Se encontrou resultados na primeira variação, pode parar (opcional)
-		// if len(variationLinks) > 0 {
-		//     break
-		// }
 	}
 	
-	// Remove duplicatas
 	uniqueLinks := removeDuplicates(allLinks)
-	fmt.Printf("Total único de links encontrados: %d\n", len(uniqueLinks))
-	
 	return uniqueLinks, nil
 }
 
-// Função para criar título padronizado substituindo apenas o início
 func createStandardizedTitle(originalTitle, year, releaseTitle string) string {
-	// Se não tiver originalTitle, retorna o magnet original
 	if originalTitle == "" {
 		return releaseTitle
 	}
 	
-	// Limpa o título original (remove caracteres especiais, substitui espaços por pontos)
 	cleanOriginalTitle := strings.ReplaceAll(originalTitle, " ", ".")
 	cleanOriginalTitle = regexp.MustCompile(`[^\w\.\-]`).ReplaceAllString(cleanOriginalTitle, "")
 	
-	// Regex para encontrar ano (4 dígitos)
 	yearRegex := regexp.MustCompile(`(19|20)\d{2}`)
-	
-	// Regex para encontrar temporada (SxxExx ou SxxE padrão)
 	seasonRegex := regexp.MustCompile(`(?i)s\d{1,2}e?\d{0,2}`)
 	
-	// Procura por ano primeiro
 	if yearMatch := yearRegex.FindStringIndex(releaseTitle); yearMatch != nil {
-		// Encontrou ano - substitui tudo antes do ano
 		beforeYear := releaseTitle[:yearMatch[0]]
 		fromYear := releaseTitle[yearMatch[0]:]
 		
-		// Remove pontos/espaços extras no final do início
 		beforeYear = strings.TrimRight(beforeYear, ". ")
 		if beforeYear != "" {
 			return cleanOriginalTitle + "." + fromYear
@@ -156,13 +123,10 @@ func createStandardizedTitle(originalTitle, year, releaseTitle string) string {
 		}
 	}
 	
-	// Se não encontrou ano, procura por temporada
 	if seasonMatch := seasonRegex.FindStringIndex(releaseTitle); seasonMatch != nil {
-		// Encontrou temporada - substitui tudo antes da temporada
 		beforeSeason := releaseTitle[:seasonMatch[0]]
 		fromSeason := releaseTitle[seasonMatch[0]:]
 		
-		// Remove pontos/espaços extras no final do início
 		beforeSeason = strings.TrimRight(beforeSeason, ". ")
 		if beforeSeason != "" {
 			return cleanOriginalTitle + "." + fromSeason
@@ -171,7 +135,6 @@ func createStandardizedTitle(originalTitle, year, releaseTitle string) string {
 		}
 	}
 	
-	// Se não encontrou nem ano nem temporada, retorna o magnet original
 	return releaseTitle
 }
 
@@ -192,7 +155,6 @@ func (i *Indexer) HandlerStarckFilmesIndexer(w http.ResponseWriter, r *http.Requ
 	var err error
 
 	if q != "" {
-		// Usa a nova função de busca com variações
 		links, err = i.trySearchVariations(ctx, metadata.URL, metadata.SearchURL, q)
 		if err != nil {
 			w.WriteHeader(http.StatusInternalServerError)
@@ -201,7 +163,6 @@ func (i *Indexer) HandlerStarckFilmesIndexer(w http.ResponseWriter, r *http.Requ
 			return
 		}
 	} else {
-		// Para paginação ou busca sem termo, usa a lógica original
 		urlStr := metadata.URL
 		if page != "" {
 			urlStr = fmt.Sprintf(fmt.Sprintf("%s%s", urlStr, metadata.PagePattern), page)
@@ -209,7 +170,6 @@ func (i *Indexer) HandlerStarckFilmesIndexer(w http.ResponseWriter, r *http.Requ
 			urlStr = fmt.Sprintf(fmt.Sprintf("%s%s", urlStr, metadata.PagePattern), "1")
 		}
 
-		fmt.Println("URL de paginação:>", urlStr)
 		resp, err := i.requester.GetDocument(ctx, urlStr)
 		if err != nil {
 			w.WriteHeader(http.StatusInternalServerError)
@@ -279,7 +239,6 @@ func getTorrentStarckFilmes(ctx context.Context, i *Indexer, link string) ([]sch
 		})
 	})
 
-	// Se não encontrou o título original, usa o título da página
 	if originalTitle == "" {
 		originalTitle = pageTitle
 	}
@@ -317,6 +276,9 @@ func getTorrentStarckFilmes(ctx context.Context, i *Indexer, link string) ([]sch
 	for it, magnetLink := range magnetLinks {
 		it := it
 		go func(it int, magnetLink string) {
+			magnetLink = strings.ReplaceAll(magnetLink, "&#038;", "&")
+			magnetLink = strings.ReplaceAll(magnetLink, "&amp;", "&")
+			
 			magnet, err := magnet.ParseMagnetUri(magnetLink)
 			if err != nil {
 				fmt.Println(err)
@@ -328,13 +290,15 @@ func getTorrentStarckFilmes(ctx context.Context, i *Indexer, link string) ([]sch
 				originalReleaseTitle = strings.TrimSpace(magnet.DisplayName)
 			}
 
-			// Cria o título padronizado usando a nova função
 			standardizedTitle := createStandardizedTitle(originalTitle, year, originalReleaseTitle)
 
 			infoHash := magnet.InfoHash.String()
 			trackers := magnet.Trackers
 			for i, tracker := range trackers {
-				unescapedTracker, err := url.QueryUnescape(tracker)
+				unescapedTracker := strings.ReplaceAll(tracker, "&#038;", "&")
+				unescapedTracker = strings.ReplaceAll(unescapedTracker, "&amp;", "&")
+				
+				unescapedTracker, err := url.QueryUnescape(unescapedTracker)
 				if err != nil {
 					fmt.Println(err)
 				}
@@ -359,7 +323,7 @@ func getTorrentStarckFilmes(ctx context.Context, i *Indexer, link string) ([]sch
 			}
 
 			ixt := schema.IndexedTorrent{
-				Title:         standardizedTitle, // Usa o título padronizado
+				Title:         standardizedTitle,
 				OriginalTitle: pageTitle,
 				Details:       link,
 				Year:          year,

--- a/api/torrent_dos_filmes.go
+++ b/api/torrent_dos_filmes.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"regexp"
 	"strings"
 	"time"
 
@@ -24,6 +25,144 @@ var torrent_dos_filmes = IndexerMeta{
 	PagePattern: "category/dublado/page/%s",
 }
 
+// Função para criar título padronizado substituindo apenas o início
+func createStandardizedTitleTDF(originalTitle, year, releaseTitle string) string {
+	// Se não tiver originalTitle, retorna o magnet original
+	if originalTitle == "" {
+		return releaseTitle
+	}
+	
+	// Limpa o título original (remove caracteres especiais, substitui espaços por pontos)
+	cleanOriginalTitle := strings.ReplaceAll(originalTitle, " ", ".")
+	cleanOriginalTitle = regexp.MustCompile(`[^\w\.\-]`).ReplaceAllString(cleanOriginalTitle, "")
+	
+	// Regex para encontrar ano (4 dígitos)
+	yearRegex := regexp.MustCompile(`(19|20)\d{2}`)
+	
+	// Regex para encontrar temporada (SxxExx ou SxxE padrão)
+	seasonRegex := regexp.MustCompile(`(?i)s\d{1,2}e?\d{0,2}`)
+	
+	// Procura por ano primeiro
+	if yearMatch := yearRegex.FindStringIndex(releaseTitle); yearMatch != nil {
+		// Encontrou ano - substitui tudo antes do ano
+		beforeYear := releaseTitle[:yearMatch[0]]
+		fromYear := releaseTitle[yearMatch[0]:]
+		
+		// Remove pontos/espaços extras no final do início
+		beforeYear = strings.TrimRight(beforeYear, ". ")
+		if beforeYear != "" {
+			return cleanOriginalTitle + "." + fromYear
+		} else {
+			return cleanOriginalTitle + "." + fromYear
+		}
+	}
+	
+	// Se não encontrou ano, procura por temporada
+	if seasonMatch := seasonRegex.FindStringIndex(releaseTitle); seasonMatch != nil {
+		// Encontrou temporada - substitui tudo antes da temporada
+		beforeSeason := releaseTitle[:seasonMatch[0]]
+		fromSeason := releaseTitle[seasonMatch[0]:]
+		
+		// Remove pontos/espaços extras no final do início
+		beforeSeason = strings.TrimRight(beforeSeason, ". ")
+		if beforeSeason != "" {
+			return cleanOriginalTitle + "." + fromSeason
+		} else {
+			return cleanOriginalTitle + "." + fromSeason
+		}
+	}
+	
+	// Se não encontrou nem ano nem temporada, retorna o magnet original
+	return releaseTitle
+}
+
+// Função para fazer busca com variações do termo - TorrentDosFilmes
+func (i *Indexer) trySearchVariationsTDF(ctx context.Context, baseURL, searchURL, query string) ([]string, error) {
+	if query == "" {
+		return nil, nil
+	}
+	
+	// Cria variações do termo de busca
+	variations := []string{
+		query, // "Amateur 2025"
+	}
+	
+	// Adiciona variação com "The" se não começar com "The"
+	firstWord := strings.Split(query, " ")[0]
+	if !strings.HasPrefix(strings.ToLower(query), "the ") {
+		variations = append(variations, "The "+firstWord)
+	}
+	
+	// Adiciona apenas o primeiro termo (sem ano)
+	if firstWord != query {
+		variations = append(variations, firstWord)
+	}
+	
+	fmt.Printf("[TorrentDosFilmes] Tentando variações de busca: %v\n", variations)
+	
+	var allLinks []string
+	
+	for _, variation := range variations {
+		fmt.Printf("[TorrentDosFilmes] Buscando por: %s\n", variation)
+		
+		encodedQuery := url.QueryEscape(variation)
+		searchURL := baseURL + searchURL + encodedQuery
+		
+		fmt.Printf("[TorrentDosFilmes] URL de busca: %s\n", searchURL)
+		
+		// Faz a requisição
+		resp, err := i.requester.GetDocument(ctx, searchURL)
+		if err != nil {
+			fmt.Printf("[TorrentDosFilmes] Erro na busca por '%s': %v\n", variation, err)
+			continue
+		}
+		
+		doc, err := goquery.NewDocumentFromReader(resp)
+		resp.Close()
+		if err != nil {
+			fmt.Printf("[TorrentDosFilmes] Erro ao parsear HTML para '%s': %v\n", variation, err)
+			continue
+		}
+		
+		// Extrai os links desta variação - seletor específico do TorrentDosFilmes
+		var variationLinks []string
+		doc.Find(".post").Each(func(j int, s *goquery.Selection) {
+			link, exists := s.Find("div.title > a").Attr("href")
+			if exists && link != "" {
+				variationLinks = append(variationLinks, link)
+			}
+		})
+		
+		fmt.Printf("[TorrentDosFilmes] Encontrados %d resultados para '%s'\n", len(variationLinks), variation)
+		allLinks = append(allLinks, variationLinks...)
+		
+		// Se encontrou resultados na primeira variação, pode parar (opcional)
+		// if len(variationLinks) > 0 {
+		//     break
+		// }
+	}
+	
+	// Remove duplicatas
+	uniqueLinks := removeDuplicatesTDF(allLinks)
+	fmt.Printf("[TorrentDosFilmes] Total único de links encontrados: %d\n", len(uniqueLinks))
+	
+	return uniqueLinks, nil
+}
+
+// Função para remover duplicatas - TorrentDosFilmes
+func removeDuplicatesTDF(links []string) []string {
+	keys := make(map[string]bool)
+	var result []string
+	
+	for _, link := range links {
+		if !keys[link] && link != "" {
+			keys[link] = true
+			result = append(result, link)
+		}
+	}
+	return result
+}
+
 func (i *Indexer) HandlerTorrentDosFilmesIndexer(w http.ResponseWriter, r *http.Request) {
 	start := time.Now()
 	metadata := torrent_dos_filmes
@@ -38,45 +177,66 @@ func (i *Indexer) HandlerTorrentDosFilmesIndexer(w http.ResponseWriter, r *http.
 	q := r.URL.Query().Get("q")
 	page := r.URL.Query().Get("page")
 
-	// URL encode query param
-	q = url.QueryEscape(q)
-	url := metadata.URL
-	if q != "" {
-		url = fmt.Sprintf("%s%s%s", url, metadata.SearchURL, q)
-	} else if page != "" {
-		url = fmt.Sprintf(fmt.Sprintf("%s%s", url, metadata.PagePattern), page)
-	}
-
-	fmt.Println("URL:>", url)
-	resp, err := i.requester.GetDocument(ctx, url)
-	if err != nil {
-		w.WriteHeader(http.StatusInternalServerError)
-		err = json.NewEncoder(w).Encode(map[string]string{"error": err.Error()})
-		if err != nil {
-			fmt.Println(err)
-		}
-		i.metrics.IndexerErrors.WithLabelValues(metadata.Label).Inc()
-		return
-	}
-	defer resp.Close()
-
-	doc, err := goquery.NewDocumentFromReader(resp)
-	if err != nil {
-		w.WriteHeader(http.StatusInternalServerError)
-		err = json.NewEncoder(w).Encode(map[string]string{"error": err.Error()})
-		if err != nil {
-			fmt.Println(err)
-		}
-
-		i.metrics.IndexerErrors.WithLabelValues(metadata.Label).Inc()
-		return
-	}
-
 	var links []string
-	doc.Find(".post").Each(func(i int, s *goquery.Selection) {
-		link, _ := s.Find("div.title > a").Attr("href")
-		links = append(links, link)
-	})
+	var err error
+
+	if q != "" {
+		// Usa a nova função de busca com variações
+		links, err = i.trySearchVariationsTDF(ctx, metadata.URL, metadata.SearchURL, q)
+		if err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			err = json.NewEncoder(w).Encode(map[string]string{"error": err.Error()})
+			if err != nil {
+				fmt.Println(err)
+			}
+			i.metrics.IndexerErrors.WithLabelValues(metadata.Label).Inc()
+			return
+		}
+	} else {
+		// Para paginação ou busca sem termo, usa a lógica original
+		url := metadata.URL
+		if page != "" {
+			url = fmt.Sprintf(fmt.Sprintf("%s%s", url, metadata.PagePattern), page)
+		}
+
+		fmt.Println("[TorrentDosFilmes] URL de paginação:>", url)
+		resp, err := i.requester.GetDocument(ctx, url)
+		if err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			err = json.NewEncoder(w).Encode(map[string]string{"error": err.Error()})
+			if err != nil {
+				fmt.Println(err)
+			}
+			i.metrics.IndexerErrors.WithLabelValues(metadata.Label).Inc()
+			return
+		}
+		defer resp.Close()
+
+		doc, err := goquery.NewDocumentFromReader(resp)
+		if err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			err = json.NewEncoder(w).Encode(map[string]string{"error": err.Error()})
+			if err != nil {
+				fmt.Println(err)
+			}
+			i.metrics.IndexerErrors.WithLabelValues(metadata.Label).Inc()
+			return
+		}
+
+		doc.Find(".post").Each(func(i int, s *goquery.Selection) {
+			link, _ := s.Find("div.title > a").Attr("href")
+			if link != "" {
+				links = append(links, link)
+			}
+		})
+	}
+
+	// if no links were indexed, expire the document in cache
+	if len(links) == 0 {
+		if q != "" {
+			fmt.Printf("[TorrentDosFilmes] Nenhum resultado encontrado para: %s\n", q)
+		}
+	}
 
 	// extract each torrent link
 	indexedTorrents := utils.ParallelFlatMap(links, func(link string) ([]schema.IndexedTorrent, error) {
@@ -107,7 +267,7 @@ func getTorrentsTorrentDosFilmes(ctx context.Context, i *Indexer, link string) (
 	}
 
 	article := doc.Find("article")
-	title := strings.Replace(article.Find(".title > h1").Text(), " - Download", "", -1)
+	pageTitle := strings.Replace(article.Find(".title > h1").Text(), " - Download", "", -1)
 	textContent := article.Find("div.content")
 	date := getPublishedDateFromMeta(doc)
 	magnets := textContent.Find("a[href^=\"magnet\"]")
@@ -116,6 +276,53 @@ func getTorrentsTorrentDosFilmes(ctx context.Context, i *Indexer, link string) (
 		magnetLink, _ := s.Attr("href")
 		magnetLinks = append(magnetLinks, magnetLink)
 	})
+
+	// Procura pelo título original no HTML
+	var originalTitle string
+	article.Find("div.content").Each(func(i int, s *goquery.Selection) {
+		// Busca no HTML bruto por padrões como "Titulo Original:" ou "Título Original:"
+		htmlContent, _ := s.Html()
+		
+		// Regex para capturar título original (com ou sem acento)
+		titleRegex := regexp.MustCompile(`(?i)t[íi]tulo\s+original:\s*</b>\s*([^<\n\r]+)`)
+		if matches := titleRegex.FindStringSubmatch(htmlContent); len(matches) > 1 {
+			originalTitle = strings.TrimSpace(matches[1])
+			fmt.Printf("[TorrentDosFilmes] Título Original encontrado: '%s'\n", originalTitle)
+		}
+		
+		// Fallback: busca no texto simples
+		if originalTitle == "" {
+			text := s.Text()
+			if strings.Contains(text, "Título Original:") {
+				parts := strings.Split(text, "Título Original:")
+				if len(parts) > 1 {
+					// Pega tudo até a próxima quebra de linha ou tag
+					titlePart := strings.TrimSpace(parts[1])
+					lines := strings.Split(titlePart, "\n")
+					if len(lines) > 0 {
+						originalTitle = strings.TrimSpace(lines[0])
+						fmt.Printf("[TorrentDosFilmes] Título Original (fallback) encontrado: '%s'\n", originalTitle)
+					}
+				}
+			} else if strings.Contains(text, "Titulo Original:") {
+				// Versão sem acento
+				parts := strings.Split(text, "Titulo Original:")
+				if len(parts) > 1 {
+					titlePart := strings.TrimSpace(parts[1])
+					lines := strings.Split(titlePart, "\n")
+					if len(lines) > 0 {
+						originalTitle = strings.TrimSpace(lines[0])
+						fmt.Printf("[TorrentDosFilmes] Titulo Original (sem acento) encontrado: '%s'\n", originalTitle)
+					}
+				}
+			}
+		}
+	})
+
+	// Se não encontrou o título original, usa o título da página
+	if originalTitle == "" {
+		originalTitle = pageTitle
+	}
 
 	var audio []schema.Audio
 	var year string
@@ -140,7 +347,7 @@ func getTorrentsTorrentDosFilmes(ctx context.Context, i *Indexer, link string) (
 		text := s.Text()
 
 		audio = append(audio, findAudioFromText(text)...)
-		y := findYearFromText(text, title)
+		y := findYearFromText(text, pageTitle)
 		if y != "" {
 			year = y
 		}
@@ -169,17 +376,34 @@ func getTorrentsTorrentDosFilmes(ctx context.Context, i *Indexer, link string) (
 			if err != nil {
 				fmt.Println(err)
 			}
-			releaseTitle := magnet.DisplayName
+
+			originalReleaseTitle := strings.TrimSpace(magnet.DisplayName)
+			originalReleaseTitle, err = url.QueryUnescape(originalReleaseTitle)
+			if err != nil {
+				originalReleaseTitle = strings.TrimSpace(magnet.DisplayName)
+			}
+
+			// Cria o título padronizado usando a nova função
+			standardizedTitle := createStandardizedTitleTDF(originalTitle, year, originalReleaseTitle)
+
 			infoHash := magnet.InfoHash.String()
 			trackers := magnet.Trackers
-			magnetAudio := getAudioFromTitle(releaseTitle, audio)
+			for i, tracker := range trackers {
+				unescapedTracker, err := url.QueryUnescape(tracker)
+				if err != nil {
+					fmt.Println(err)
+				}
+				trackers[i] = strings.TrimSpace(unescapedTracker)
+			}
+
+			magnetAudio := getAudioFromTitle(originalReleaseTitle, audio)
 
 			peer, seed, err := goscrape.GetLeechsAndSeeds(ctx, i.redis, i.metrics, infoHash, trackers)
 			if err != nil {
 				fmt.Println(err)
 			}
 
-			title := processTitle(title, magnetAudio)
+			processedTitle := processTitle(pageTitle, magnetAudio)
 
 			// if the number of sizes is equal to the number of magnets, then assign the size to each indexed torrent in order
 			var mySize string
@@ -193,8 +417,8 @@ func getTorrentsTorrentDosFilmes(ctx context.Context, i *Indexer, link string) (
 			}
 
 			ixt := schema.IndexedTorrent{
-				Title:         releaseTitle,
-				OriginalTitle: title,
+				Title:         standardizedTitle, // Usa o título padronizado
+				OriginalTitle: processedTitle,
 				Details:       link,
 				Year:          year,
 				IMDB:          imdbLink,

--- a/api/torrent_dos_filmes.go
+++ b/api/torrent_dos_filmes.go
@@ -25,30 +25,21 @@ var torrent_dos_filmes = IndexerMeta{
 	PagePattern: "category/dublado/page/%s",
 }
 
-// Função para criar título padronizado substituindo apenas o início
 func createStandardizedTitleTDF(originalTitle, year, releaseTitle string) string {
-	// Se não tiver originalTitle, retorna o magnet original
 	if originalTitle == "" {
 		return releaseTitle
 	}
 	
-	// Limpa o título original (remove caracteres especiais, substitui espaços por pontos)
 	cleanOriginalTitle := strings.ReplaceAll(originalTitle, " ", ".")
 	cleanOriginalTitle = regexp.MustCompile(`[^\w\.\-]`).ReplaceAllString(cleanOriginalTitle, "")
 	
-	// Regex para encontrar ano (4 dígitos)
 	yearRegex := regexp.MustCompile(`(19|20)\d{2}`)
-	
-	// Regex para encontrar temporada (SxxExx ou SxxE padrão)
 	seasonRegex := regexp.MustCompile(`(?i)s\d{1,2}e?\d{0,2}`)
 	
-	// Procura por ano primeiro
 	if yearMatch := yearRegex.FindStringIndex(releaseTitle); yearMatch != nil {
-		// Encontrou ano - substitui tudo antes do ano
 		beforeYear := releaseTitle[:yearMatch[0]]
 		fromYear := releaseTitle[yearMatch[0]:]
 		
-		// Remove pontos/espaços extras no final do início
 		beforeYear = strings.TrimRight(beforeYear, ". ")
 		if beforeYear != "" {
 			return cleanOriginalTitle + "." + fromYear
@@ -57,13 +48,10 @@ func createStandardizedTitleTDF(originalTitle, year, releaseTitle string) string
 		}
 	}
 	
-	// Se não encontrou ano, procura por temporada
 	if seasonMatch := seasonRegex.FindStringIndex(releaseTitle); seasonMatch != nil {
-		// Encontrou temporada - substitui tudo antes da temporada
 		beforeSeason := releaseTitle[:seasonMatch[0]]
 		fromSeason := releaseTitle[seasonMatch[0]:]
 		
-		// Remove pontos/espaços extras no final do início
 		beforeSeason = strings.TrimRight(beforeSeason, ". ")
 		if beforeSeason != "" {
 			return cleanOriginalTitle + "." + fromSeason
@@ -72,59 +60,44 @@ func createStandardizedTitleTDF(originalTitle, year, releaseTitle string) string
 		}
 	}
 	
-	// Se não encontrou nem ano nem temporada, retorna o magnet original
 	return releaseTitle
 }
 
-// Função para fazer busca com variações do termo - TorrentDosFilmes
 func (i *Indexer) trySearchVariationsTDF(ctx context.Context, baseURL, searchURL, query string) ([]string, error) {
 	if query == "" {
 		return nil, nil
 	}
 	
-	// Cria variações do termo de busca
 	variations := []string{
-		query, // "Amateur 2025"
+		query,
 	}
 	
-	// Adiciona variação com "The" se não começar com "The"
 	firstWord := strings.Split(query, " ")[0]
 	if !strings.HasPrefix(strings.ToLower(query), "the ") {
 		variations = append(variations, "The "+firstWord)
 	}
 	
-	// Adiciona apenas o primeiro termo (sem ano)
 	if firstWord != query {
 		variations = append(variations, firstWord)
 	}
 	
-	fmt.Printf("[TorrentDosFilmes] Tentando variações de busca: %v\n", variations)
-	
 	var allLinks []string
 	
 	for _, variation := range variations {
-		fmt.Printf("[TorrentDosFilmes] Buscando por: %s\n", variation)
-		
 		encodedQuery := url.QueryEscape(variation)
 		searchURL := baseURL + searchURL + encodedQuery
 		
-		fmt.Printf("[TorrentDosFilmes] URL de busca: %s\n", searchURL)
-		
-		// Faz a requisição
 		resp, err := i.requester.GetDocument(ctx, searchURL)
 		if err != nil {
-			fmt.Printf("[TorrentDosFilmes] Erro na busca por '%s': %v\n", variation, err)
 			continue
 		}
 		
 		doc, err := goquery.NewDocumentFromReader(resp)
 		resp.Close()
 		if err != nil {
-			fmt.Printf("[TorrentDosFilmes] Erro ao parsear HTML para '%s': %v\n", variation, err)
 			continue
 		}
 		
-		// Extrai os links desta variação - seletor específico do TorrentDosFilmes
 		var variationLinks []string
 		doc.Find(".post").Each(func(j int, s *goquery.Selection) {
 			link, exists := s.Find("div.title > a").Attr("href")
@@ -133,23 +106,13 @@ func (i *Indexer) trySearchVariationsTDF(ctx context.Context, baseURL, searchURL
 			}
 		})
 		
-		fmt.Printf("[TorrentDosFilmes] Encontrados %d resultados para '%s'\n", len(variationLinks), variation)
 		allLinks = append(allLinks, variationLinks...)
-		
-		// Se encontrou resultados na primeira variação, pode parar (opcional)
-		// if len(variationLinks) > 0 {
-		//     break
-		// }
 	}
 	
-	// Remove duplicatas
 	uniqueLinks := removeDuplicatesTDF(allLinks)
-	fmt.Printf("[TorrentDosFilmes] Total único de links encontrados: %d\n", len(uniqueLinks))
-	
 	return uniqueLinks, nil
 }
 
-// Função para remover duplicatas - TorrentDosFilmes
 func removeDuplicatesTDF(links []string) []string {
 	keys := make(map[string]bool)
 	var result []string
@@ -173,7 +136,6 @@ func (i *Indexer) HandlerTorrentDosFilmesIndexer(w http.ResponseWriter, r *http.
 	}()
 
 	ctx := r.Context()
-	// supported query params: q, season, episode, page, filter_results
 	q := r.URL.Query().Get("q")
 	page := r.URL.Query().Get("page")
 
@@ -181,7 +143,6 @@ func (i *Indexer) HandlerTorrentDosFilmesIndexer(w http.ResponseWriter, r *http.
 	var err error
 
 	if q != "" {
-		// Usa a nova função de busca com variações
 		links, err = i.trySearchVariationsTDF(ctx, metadata.URL, metadata.SearchURL, q)
 		if err != nil {
 			w.WriteHeader(http.StatusInternalServerError)
@@ -193,13 +154,11 @@ func (i *Indexer) HandlerTorrentDosFilmesIndexer(w http.ResponseWriter, r *http.
 			return
 		}
 	} else {
-		// Para paginação ou busca sem termo, usa a lógica original
 		url := metadata.URL
 		if page != "" {
 			url = fmt.Sprintf(fmt.Sprintf("%s%s", url, metadata.PagePattern), page)
 		}
 
-		fmt.Println("[TorrentDosFilmes] URL de paginação:>", url)
 		resp, err := i.requester.GetDocument(ctx, url)
 		if err != nil {
 			w.WriteHeader(http.StatusInternalServerError)
@@ -231,19 +190,14 @@ func (i *Indexer) HandlerTorrentDosFilmesIndexer(w http.ResponseWriter, r *http.
 		})
 	}
 
-	// if no links were indexed, expire the document in cache
 	if len(links) == 0 {
-		if q != "" {
-			fmt.Printf("[TorrentDosFilmes] Nenhum resultado encontrado para: %s\n", q)
-		}
+		
 	}
 
-	// extract each torrent link
 	indexedTorrents := utils.ParallelFlatMap(links, func(link string) ([]schema.IndexedTorrent, error) {
 		return getTorrentsTorrentDosFilmes(ctx, i, link)
 	})
 
-	// Apply post-processors
 	postProcessedTorrents := indexedTorrents
 	for _, processor := range i.postProcessors {
 		postProcessedTorrents = processor(i, r, postProcessedTorrents)
@@ -277,49 +231,39 @@ func getTorrentsTorrentDosFilmes(ctx context.Context, i *Indexer, link string) (
 		magnetLinks = append(magnetLinks, magnetLink)
 	})
 
-	// Procura pelo título original no HTML
 	var originalTitle string
 	article.Find("div.content").Each(func(i int, s *goquery.Selection) {
-		// Busca no HTML bruto por padrões como "Titulo Original:" ou "Título Original:"
 		htmlContent, _ := s.Html()
 		
-		// Regex para capturar título original (com ou sem acento)
 		titleRegex := regexp.MustCompile(`(?i)t[íi]tulo\s+original:\s*</b>\s*([^<\n\r]+)`)
 		if matches := titleRegex.FindStringSubmatch(htmlContent); len(matches) > 1 {
 			originalTitle = strings.TrimSpace(matches[1])
-			fmt.Printf("[TorrentDosFilmes] Título Original encontrado: '%s'\n", originalTitle)
 		}
 		
-		// Fallback: busca no texto simples
 		if originalTitle == "" {
 			text := s.Text()
 			if strings.Contains(text, "Título Original:") {
 				parts := strings.Split(text, "Título Original:")
 				if len(parts) > 1 {
-					// Pega tudo até a próxima quebra de linha ou tag
 					titlePart := strings.TrimSpace(parts[1])
 					lines := strings.Split(titlePart, "\n")
 					if len(lines) > 0 {
 						originalTitle = strings.TrimSpace(lines[0])
-						fmt.Printf("[TorrentDosFilmes] Título Original (fallback) encontrado: '%s'\n", originalTitle)
 					}
 				}
 			} else if strings.Contains(text, "Titulo Original:") {
-				// Versão sem acento
 				parts := strings.Split(text, "Titulo Original:")
 				if len(parts) > 1 {
 					titlePart := strings.TrimSpace(parts[1])
 					lines := strings.Split(titlePart, "\n")
 					if len(lines) > 0 {
 						originalTitle = strings.TrimSpace(lines[0])
-						fmt.Printf("[TorrentDosFilmes] Titulo Original (sem acento) encontrado: '%s'\n", originalTitle)
 					}
 				}
 			}
 		}
 	})
 
-	// Se não encontrou o título original, usa o título da página
 	if originalTitle == "" {
 		originalTitle = pageTitle
 	}
@@ -328,22 +272,6 @@ func getTorrentsTorrentDosFilmes(ctx context.Context, i *Indexer, link string) (
 	var year string
 	var size []string
 	article.Find("div.content p").Each(func(i int, s *goquery.Selection) {
-		// pattern:
-		// Título Traduzido: Fundação
-		// Título Original: Foundation
-		// IMDb: 7,5
-		// Ano de Lançamento: 2023
-		// Gênero: Ação | Aventura | Ficção
-		// Formato: MKV
-		// Qualidade: WEB-DL
-		// Áudio: Português | Inglês
-		// Idioma: Português | Inglês
-		// Legenda: Português
-		// Tamanho: –
-		// Qualidade de Áudio: 10
-		// Qualidade de Vídeo: 10
-		// Duração: 59 Min.
-		// Servidor: Torrent
 		text := s.Text()
 
 		audio = append(audio, findAudioFromText(text)...)
@@ -354,7 +282,6 @@ func getTorrentsTorrentDosFilmes(ctx context.Context, i *Indexer, link string) (
 		size = append(size, findSizesFromText(text)...)
 	})
 
-	// find any link from imdb
 	imdbLink := ""
 	article.Find("div.content a").Each(func(i int, s *goquery.Selection) {
 		link, _ := s.Attr("href")
@@ -368,10 +295,12 @@ func getTorrentsTorrentDosFilmes(ctx context.Context, i *Indexer, link string) (
 
 	var chanIndexedTorrent = make(chan schema.IndexedTorrent)
 
-	// for each magnet link, create a new indexed torrent
 	for it, magnetLink := range magnetLinks {
 		it := it
 		go func(it int, magnetLink string) {
+			magnetLink = strings.ReplaceAll(magnetLink, "&#038;", "&")
+			magnetLink = strings.ReplaceAll(magnetLink, "&amp;", "&")
+			
 			magnet, err := magnet.ParseMagnetUri(magnetLink)
 			if err != nil {
 				fmt.Println(err)
@@ -383,13 +312,15 @@ func getTorrentsTorrentDosFilmes(ctx context.Context, i *Indexer, link string) (
 				originalReleaseTitle = strings.TrimSpace(magnet.DisplayName)
 			}
 
-			// Cria o título padronizado usando a nova função
 			standardizedTitle := createStandardizedTitleTDF(originalTitle, year, originalReleaseTitle)
 
 			infoHash := magnet.InfoHash.String()
 			trackers := magnet.Trackers
 			for i, tracker := range trackers {
-				unescapedTracker, err := url.QueryUnescape(tracker)
+				unescapedTracker := strings.ReplaceAll(tracker, "&#038;", "&")
+				unescapedTracker = strings.ReplaceAll(unescapedTracker, "&amp;", "&")
+				
+				unescapedTracker, err := url.QueryUnescape(unescapedTracker)
 				if err != nil {
 					fmt.Println(err)
 				}
@@ -405,7 +336,6 @@ func getTorrentsTorrentDosFilmes(ctx context.Context, i *Indexer, link string) (
 
 			processedTitle := processTitle(pageTitle, magnetAudio)
 
-			// if the number of sizes is equal to the number of magnets, then assign the size to each indexed torrent in order
 			var mySize string
 			if len(size) == len(magnetLinks) {
 				mySize = size[it]
@@ -417,7 +347,7 @@ func getTorrentsTorrentDosFilmes(ctx context.Context, i *Indexer, link string) (
 			}
 
 			ixt := schema.IndexedTorrent{
-				Title:         standardizedTitle, // Usa o título padronizado
+				Title:         standardizedTitle,
 				OriginalTitle: processedTitle,
 				Details:       link,
 				Year:          year,


### PR DESCRIPTION
Efetuado melhorias na arquivo yml do README para melhorar a informação do radarr e sonarr

Efetuado ajustes nos arquivos go.

rede_torrent
starck_filmes
torrent_dos_filmes

Sendo feito a coleta do titulo original direto no html e inserido no resultado final fazendo com que os titulos dublados inseridos no magnet sejam substituitos pelos originais, com isso o radarr e sonarr consegue indentificar o filme / serie.

Ficando da seguinte forma no resultado 

FILMES
originalTitle.2025.1080p.BluRay.x264.DUAL
originalTitle.2025.720p.BluRay.x264.DUAL

SERIES
originalTitle.S03E01.WEB-DL.1080p.x264.DUAL.5.1
originalTitle.S03E05.WEB-DL.720p.x264.DUAL.5.1
originalTitle.S03E09.WEB-DL.1080p.x264.DUAL.5.1

