### PR TITLE
feat: Handlers dinâmicos, unificação de busca, metadados estendidos e otimizações do MeiliSearch

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ You can configure the server using the following environment variables:
 - `MAGNET_METADATA_API_ENABLED`: (optional) Enable the magnet metadata API. (deploy instrucitons [here](https://github.com/felipemarinho97/magnet-metadata-api)) Default: `false`
 - `MAGNET_METADATA_API_ADDRESS`: (optional) The address of your magnet metadata API. Default: `N/A`
 - `MAGNET_METADATA_API_TIMEOUT_SECONDS`: (optional) The timeout for the magnet metadata API requests in seconds. Default: `10`
+- `ENABLE_EXTENDED_METADATA`: (optional) Include extensive fields in search responses (e.g., duration, audio/video quality, parsed subtitles, genres). Highly useful but consumes more storage if Meilisearch/Redis is used. Default: `false`
 - `INDEXER_<NAME>_URL`: (optional) Set a custom URL for the indexer. Where the "NAME" will be always uppercase indexer key with underscores. ex: `INDEXER_DODO_FILMES_URL=https://my-proxied-dodo-url.org`
 ## Integrating with Jackett
 

--- a/api/bludv.go
+++ b/api/bludv.go
@@ -119,52 +119,136 @@ func getTorrentsBluDV(ctx context.Context, i *Indexer, link, referer string) ([]
 	textContent := article.Find("div.content")
 	date := getPublishedDate(doc)
 	magnets := textContent.Find("a[href^=\"magnet\"]")
-	var magnetLinks []string
+	var magnetLinks []ExtractedMagnet
 	magnets.Each(func(i int, s *goquery.Selection) {
 		magnetLink, _ := s.Attr("href")
-		magnetLinks = append(magnetLinks, magnetLink)
+		ctxStr := ExtractMagnetContext(s)
+		magnetLinks = append(magnetLinks, ExtractedMagnet{Link: magnetLink, Context: ctxStr})
 	})
 
-	adwareDomains := []string{
-		"https://www.seuvideo.xyz",
-		"https://www.systemads.org",
-		"https://superadsgo.xyz",
+	adwareHosts := map[string]struct{}{
+		"www.seuvideo.xyz":   {},
+		"www.systemads.org":  {},
+		"systemads.org":      {},
+		"superadsgo.xyz":     {},
+		"www.superadsgo.xyz": {},
+		"systemads.xyz":      {},
+		"www.systemads.xyz":  {},
 	}
 
-	// Process adware links for each domain in the list
-	for _, domain := range adwareDomains {
-		adwareLinks := textContent.Find(fmt.Sprintf("a[href^=\"%s\"]", domain))
-		adwareLinks.Each(func(_ int, s *goquery.Selection) {
-			href, _ := s.Attr("href")
-			// extract querysting "id" from url
-			parsedUrl, err := url.Parse(href)
-			if err != nil {
-				logging.Error().Err(err).Str("href", href).Msg("Failed to parse URL")
-				return
-			}
-			magnetLink := parsedUrl.Query().Get("id")
-			magnetLinkDecoded, err := utils.DecodeAdLink(magnetLink)
-			if err != nil {
-				logging.Error().Err(err).Str("href", href).Msg("Failed to decode ad link")
-				return
-			}
+	// Process all links and check if hostname matches known ad redirect hosts
+	textContent.Find("a[href]").Each(func(_ int, s *goquery.Selection) {
+		href, _ := s.Attr("href")
+		parsedURL, err := url.Parse(href)
+		if err != nil {
+			logging.Error().Err(err).Str("href", href).Msg("Failed to parse URL")
+			return
+		}
 
-			// if decoded magnet link is indeed a magnet link, append it
-			if strings.HasPrefix(magnetLinkDecoded, "magnet:") {
-				magnetLinks = append(magnetLinks, magnetLinkDecoded)
-			} else if !strings.Contains(magnetLinkDecoded, "watch.brplayer") {
-				logging.Warn().
-					Str("href", href).
-					Str("decoded", magnetLinkDecoded).
-					Str("indexer", bludv.Label).
-					Msg("Link decoding resulted in non-magnet link")
+		host := strings.ToLower(parsedURL.Hostname())
+		if _, ok := adwareHosts[host]; !ok {
+			return
+		}
+
+		magnetLink := parsedURL.Query().Get("id")
+		logging.Debug().Str("encoded_id", magnetLink).Str("href", href).Msg("Attempting to decode ad link")
+		magnetLinkDecoded, err := utils.DecodeAdLink(magnetLink)
+		ctxStr := ExtractMagnetContext(s)
+		
+		pHtml, _ := s.Parent().Html()
+		logging.Debug().Str("ctxStr", ctxStr).Str("href", href).Str("parentHtml", pHtml).Msg("Extracted context for link")
+
+		// Strategy 1: Try decoding
+		if err == nil && strings.HasPrefix(magnetLinkDecoded, "magnet:") {
+			logging.Debug().Str("decoded", magnetLinkDecoded).Msg("Successfully decoded ad link")
+			magnetLinks = append(magnetLinks, ExtractedMagnet{Link: magnetLinkDecoded, Context: ctxStr})
+			return
+		}
+
+		// Strategy 2: Try resolving via HTTP HEAD to capture redirect location
+		logging.Debug().Str("href", href).Msg("Decode failed, attempting to resolve via HEAD request for redirect")
+		
+		// Make a HEAD request to capture the redirect Location header without following it
+		headReq, err := http.NewRequestWithContext(ctx, "HEAD", href, nil)
+		if err == nil {
+			// Create a custom client that doesn't follow redirects
+			client := &http.Client{
+				CheckRedirect: func(req *http.Request, via []*http.Request) error {
+					return http.ErrUseLastResponse // Don't follow redirects
+				},
+				Timeout: 10 * time.Second,
+			}
+			resp, err := client.Do(headReq)
+			if err == nil && resp.StatusCode >= 300 && resp.StatusCode < 400 {
+				location := resp.Header.Get("Location")
+				if strings.HasPrefix(location, "magnet:") {
+					logging.Debug().Str("magnet", location).Str("href", href).Msg("Extracted magnet from redirect Location header")
+					magnetLinks = append(magnetLinks, ExtractedMagnet{Link: location, Context: ctxStr})
+					resp.Body.Close()
+					return
+				}
+				resp.Body.Close()
+			}
+		}
+
+		// Fallback: Try resolving via FlareSolverr and look for magnet in HTML
+		doc, err := getDocument(ctx, i, href, referer)
+		if err != nil {
+			logging.Error().Err(err).Str("href", href).Msg("Failed to resolve ad link via FlareSolverr")
+			return
+		}
+
+		// Search the raw HTML for any occurrence of 'receber.php'
+		htmlContent, _ := doc.Html()
+		lines := strings.Split(htmlContent, "\n")
+		var redirectURL string
+		for _, line := range lines {
+			if strings.Contains(line, "receber.php") {
+				start := strings.Index(line, "https://")
+				if start != -1 {
+					end := strings.Index(line[start:], "\"")
+					if end != -1 {
+						redirectURL = line[start : start+end]
+						break
+					}
+					// Try single quote if double quote fails
+					end = strings.Index(line[start:], "'")
+					if end != -1 {
+						redirectURL = line[start : start+end]
+						break
+					}
+				}
+			}
+		}
+
+		if redirectURL != "" {
+			u, err := url.Parse(redirectURL)
+			if err == nil {
+				recId := u.Query().Get("id")
+				if recId != "" {
+					// Use the improved decoder which handles the reverse + base64 logic
+					decoded, err := utils.DecodeAdLink(recId)
+					if err == nil && strings.HasPrefix(decoded, "magnet:") {
+						logging.Debug().Str("magnet", decoded).Str("from", redirectURL).Msg("Extracted magnet using spider logic")
+						magnetLinks = append(magnetLinks, ExtractedMagnet{Link: decoded, Context: ctxStr})
+					}
+				}
+			}
+		}
+
+		// Look for magnet links in the resolved page (direct magnets fallback)
+		doc.Find("a[href^=\"magnet:\"]").Each(func(_ int, elem *goquery.Selection) {
+			if magnet, ok := elem.Attr("href"); ok && strings.HasPrefix(magnet, "magnet:") {
+				logging.Debug().Str("magnet", magnet).Str("href", href).Msg("Extracted magnet from resolved ad link")
+				magnetLinks = append(magnetLinks, ExtractedMagnet{Link: magnet, Context: ctxStr})
 			}
 		})
-	}
+	})
 
 	var audio []schema.Audio
 	var year string
 	var size []string
+	var allText strings.Builder
 	article.Find("div.content p").Each(func(i int, s *goquery.Selection) {
 		// pattern:
 		// Título Traduzido: Fundação
@@ -183,6 +267,7 @@ func getTorrentsBluDV(ctx context.Context, i *Indexer, link, referer string) ([]
 		// Duração: 59 Min.
 		// Servidor: Torrent
 		text := s.Text()
+		allText.WriteString(text + "\n")
 
 		audio = append(audio, findAudioFromText(text)...)
 		y := findYearFromText(text, title)
@@ -202,14 +287,15 @@ func getTorrentsBluDV(ctx context.Context, i *Indexer, link, referer string) ([]
 		}
 	})
 
-	size = utils.StableUniq(size)
+	// // size = utils.StableUniq(size) // Fixed bug: do not deduplicate sizes // Fixed bug: do not deduplicate sizes
 
 	var chanIndexedTorrent = make(chan schema.IndexedTorrent)
 
 	// for each magnet link, create a new indexed torrent
-	for it, magnetLink := range magnetLinks {
+	for it, magnetInfo := range magnetLinks {
 		it := it
-		go func(it int, magnetLink string) {
+		go func(it int, magnetInfo ExtractedMagnet) {
+			magnetLink := magnetInfo.Link
 			magnet, err := magnet.ParseMagnetUri(magnetLink)
 			if err != nil {
 				logging.Error().Err(err).Str("magnet_link", magnetLink).Msg("Failed to parse magnet URI")
@@ -225,11 +311,32 @@ func getTorrentsBluDV(ctx context.Context, i *Indexer, link, referer string) ([]
 			}
 
 			title := processTitle(title, magnetAudio)
+			
+			if releaseTitle == "" {
+				releaseTitle = title
+			}
+
+			var ctxCln string
+			if magnetInfo.Context != "" {
+				ctxCln = strings.TrimSpace(magnetInfo.Context)
+			}
 
 			// if the number of sizes is equal to the number of magnets, then assign the size to each indexed torrent in order
 			var mySize string
 			if len(size) == len(magnetLinks) {
 				mySize = size[it]
+			} else if len(size) > 0 {
+				if it < len(size) {
+					mySize = size[it]
+				} else {
+					mySize = size[0]
+				}
+			} else if len(size) > 0 {
+				if it < len(size) {
+					mySize = size[it]
+				} else {
+					mySize = size[0]
+				}
 			}
 			if mySize == "" {
 				go func() {
@@ -251,9 +358,13 @@ func getTorrentsBluDV(ctx context.Context, i *Indexer, link, referer string) ([]
 				LeechCount:    peer,
 				SeedCount:     seed,
 				Size:          mySize,
+				Context:       ctxCln,
 			}
+			
+			extractExtendedMetadata(allText.String(), &ixt)
+			
 			chanIndexedTorrent <- ixt
-		}(it, magnetLink)
+		}(it, magnetInfo)
 	}
 
 	for i := 0; i < len(magnetLinks); i++ {

--- a/api/comando_torrents.go
+++ b/api/comando_torrents.go
@@ -151,6 +151,65 @@ func getTorrents(ctx context.Context, i *Indexer, link, referer string) ([]schem
 		magnetLinks = append(magnetLinks, ExtractedMagnet{Link: magnetLink, Context: ctxStr})
 	})
 
+	adwareHosts := map[string]struct{}{
+		"www.seuvideo.xyz":   {},
+		"www.systemads.org":  {},
+		"systemads.org":      {},
+		"superadsgo.xyz":     {},
+		"www.superadsgo.xyz": {},
+		"systemads.xyz":      {},
+		"www.systemads.xyz":  {},
+	}
+
+	// Process all links and check if hostname matches known ad redirect hosts
+	textContent.Find("a[href]").Each(func(_ int, s *goquery.Selection) {
+		href, _ := s.Attr("href")
+		parsedURL, err := url.Parse(href)
+		if err != nil {
+			logging.Error().Err(err).Str("href", href).Msg("Failed to parse URL")
+			return
+		}
+
+		host := strings.ToLower(parsedURL.Hostname())
+		if _, ok := adwareHosts[host]; !ok {
+			return
+		}
+
+		// Fallback: Try resolving via FlareSolverr and look for magnet in HTML
+		doc, err := getDocument(ctx, i, href, referer)
+		if err != nil {
+			logging.Error().Err(err).Str("href", href).Msg("Failed to resolve ad link via FlareSolverr")
+			return
+		}
+
+		// Smart Extraction: Look for ANY URL with a suspicious ID parameter
+		htmlContent, _ := doc.Html()
+
+		smartRe := regexp.MustCompile(`https?://[^"'\s?]+\.(php|xyz|info|top)[^"'\s]*[?&](id|u|link)=([A-Za-z0-9+/=%]{30,})`)
+		smartMatches := smartRe.FindAllStringSubmatch(htmlContent, -1)
+
+		ctxStr := ExtractMagnetContext(s)
+
+		for _, match := range smartMatches {
+			if len(match) < 4 {
+				continue
+			}
+			recId := match[3]
+
+			decoded, err := utils.DecodeAdLink(recId)
+			if err == nil && strings.HasPrefix(decoded, "magnet:") {
+				magnetLinks = append(magnetLinks, ExtractedMagnet{Link: decoded, Context: ctxStr})
+			}
+		}
+
+		// Look for magnet links in the resolved page (direct magnets fallback)
+		doc.Find("a[href^=\"magnet:\"]").Each(func(_ int, elem *goquery.Selection) {
+			if magnetLink, ok := elem.Attr("href"); ok && strings.HasPrefix(magnetLink, "magnet:") {
+				magnetLinks = append(magnetLinks, ExtractedMagnet{Link: magnetLink, Context: ctxStr})
+			}
+		})
+	})
+
 	var audio []schema.Audio
 	var year string
 	var size []string

--- a/api/comando_torrents.go
+++ b/api/comando_torrents.go
@@ -144,33 +144,20 @@ func getTorrents(ctx context.Context, i *Indexer, link, referer string) ([]schem
 	}
 
 	magnets := textContent.Find("a[href^=\"magnet\"]")
-	var magnetLinks []string
+	var magnetLinks []ExtractedMagnet
 	magnets.Each(func(i int, s *goquery.Selection) {
 		magnetLink, _ := s.Attr("href")
-		magnetLinks = append(magnetLinks, magnetLink)
+		ctxStr := ExtractMagnetContext(s)
+		magnetLinks = append(magnetLinks, ExtractedMagnet{Link: magnetLink, Context: ctxStr})
 	})
 
 	var audio []schema.Audio
 	var year string
 	var size []string
+	var allText strings.Builder
 	article.Find("div.entry-content > p").Each(func(i int, s *goquery.Selection) {
-		// pattern:
-		// Título Traduzido: Fundação
-		// Título Original: Foundation
-		// IMDb: 7,5
-		// Ano de Lançamento: 2023
-		// Gênero: Ação | Aventura | Ficção
-		// Formato: MKV
-		// Qualidade: WEB-DL
-		// Áudio: Português | Inglês
-		// Idioma: Português | Inglês
-		// Legenda: Português
-		// Tamanho: –
-		// Qualidade de Áudio: 10
-		// Qualidade de Vídeo: 10
-		// Duração: 59 Min.
-		// Servidor: Torrent
 		text := s.Text()
+		allText.WriteString(text + "\n")
 
 		audio = append(audio, findAudioFromText(text)...)
 		y := findYearFromText(text, title)
@@ -190,14 +177,15 @@ func getTorrents(ctx context.Context, i *Indexer, link, referer string) ([]schem
 		}
 	})
 
-	size = utils.StableUniq(size)
+	// // size = utils.StableUniq(size) // Fixed bug: do not deduplicate sizes // Fixed bug: do not deduplicate sizes
 
 	var chanIndexedTorrent = make(chan schema.IndexedTorrent)
 
 	// for each magnet link, create a new indexed torrent
-	for it, magnetLink := range magnetLinks {
+	for it, magnetInfo := range magnetLinks {
 		it := it
-		go func(it int, magnetLink string) {
+		go func(it int, magnetInfo ExtractedMagnet) {
+			magnetLink := magnetInfo.Link
 			magnet, err := magnet.ParseMagnetUri(magnetLink)
 			if err != nil {
 				logging.Error().Err(err).Str("magnet_link", magnetLink).Msg("Failed to parse magnet URI")
@@ -213,11 +201,28 @@ func getTorrents(ctx context.Context, i *Indexer, link, referer string) ([]schem
 			}
 
 			title := processTitle(title, magnetAudio)
+			
+			var ctxCln string
+			if magnetInfo.Context != "" {
+				ctxCln = strings.TrimSpace(magnetInfo.Context)
+			}
 
 			// if the number of sizes is equal to the number of magnets, then assign the size to each indexed torrent in order
 			var mySize string
 			if len(size) == len(magnetLinks) {
 				mySize = size[it]
+			} else if len(size) > 0 {
+				if it < len(size) {
+					mySize = size[it]
+				} else {
+					mySize = size[0]
+				}
+			} else if len(size) > 0 {
+				if it < len(size) {
+					mySize = size[it]
+				} else {
+					mySize = size[0]
+				}
 			}
 			if mySize == "" {
 				go func() {
@@ -239,9 +244,13 @@ func getTorrents(ctx context.Context, i *Indexer, link, referer string) ([]schem
 				LeechCount:    peer,
 				SeedCount:     seed,
 				Size:          mySize,
+				Context:       ctxCln,
 			}
+			
+			extractExtendedMetadata(allText.String(), &ixt)
+			
 			chanIndexedTorrent <- ixt
-		}(it, magnetLink)
+		}(it, magnetInfo)
 	}
 
 	for i := 0; i < len(magnetLinks); i++ {

--- a/api/common.go
+++ b/api/common.go
@@ -14,6 +14,7 @@ import (
 	"github.com/PuerkitoBio/goquery"
 	"github.com/felipemarinho97/torrent-indexer/logging"
 	"github.com/felipemarinho97/torrent-indexer/schema"
+	"golang.org/x/net/html"
 )
 
 // getDocument retrieves a document from the cache or makes a request to get it.
@@ -130,7 +131,8 @@ func getSeparator(s string) string {
 	} else if strings.Contains(s, " e ") {
 		return " e "
 	}
-	return " "
+	// default fallback that won't split single values containing spaces
+	return " | "
 }
 
 // findAudioFromText extracts audio languages from a given text.
@@ -269,4 +271,225 @@ func getAudioFromTitle(releaseTitle string, audioFromContent []schema.Audio) []s
 	})
 
 	return magnetAudio
+}
+
+// extractExtendedMetadata extracts quality, video quality, audio quality, genres, subtitles, duration, and classification from text.
+func extractExtendedMetadata(text string, ixt *schema.IndexedTorrent) {
+	if q := findMetadataField(text, []string{"Qualidade"}); q != "" {
+		ixt.Quality = q
+	}
+	if vq := findMetadataField(text, []string{"Qualidade de V.deo", "V.deo"}); vq != "" {
+		vq = strings.Split(vq, " e ")[0]
+		ixt.VideoQuality = strings.TrimSpace(vq)
+	}
+	if aq := findMetadataField(text, []string{"Qualidade d[oe] .udio", ".udio"}); aq != "" {
+		aq = strings.Split(aq, " e ")[0]
+		ixt.AudioQuality = strings.TrimSpace(aq)
+	}
+	if g := findMetadataField(text, []string{"G.neros?", "Categoria"}); g != "" {
+		genres := strings.Split(g, getSeparator(g))
+		for i, v := range genres {
+			genres[i] = strings.TrimSpace(v)
+		}
+		ixt.Genres = genres
+	}
+	if s := findMetadataField(text, []string{"Legendas?"}); s != "" {
+		subs := strings.Split(s, getSeparator(s))
+		for i, v := range subs {
+			val := strings.TrimSpace(v)
+			if strings.EqualFold(val, "S") || strings.EqualFold(val, "L") || strings.EqualFold(val, "Sim") {
+				val = "Português"
+			}
+			subs[i] = val
+		}
+		ixt.Subtitles = subs
+	}
+	if d := findMetadataField(text, []string{"Dura..o"}); d != "" {
+		ixt.Duration = d
+	}
+	if c := findMetadataField(text, []string{"Classifica..o", "Classifica..o Indicativa"}); c != "" {
+		ixt.Classification = c
+	}
+}
+
+// findMetadataField tries to extract a value from the info text block using regexes
+func findMetadataField(text string, patterns []string) string {
+	for _, p := range patterns {
+		re := regexp.MustCompile(fmt.Sprintf(`(?i)(?:%s):\s*(.*)`, p))
+		match := re.FindStringSubmatch(text)
+		if len(match) > 1 {
+			return strings.TrimSpace(strings.Split(match[1], "\n")[0])
+		}
+	}
+	return ""
+}
+
+// ExtractedMagnet holds the magnet link and its specific HTML context
+type ExtractedMagnet struct {
+	Link    string
+	Context string
+}
+
+// ExtractMagnetContext attempts to find descriptive text near the magnet link button
+// to differentiate multiple qualities/episodes in the same post.
+func ExtractMagnetContext(s *goquery.Selection) string {
+	context := ""
+
+	// Strategy 1: VacaTorrent fancy episode block
+	if ssEp := s.Closest(".ss-ep"); ssEp.Length() > 0 {
+		epNum := strings.TrimSpace(ssEp.Find(".ss-ep-num").Text())
+		btnText := strings.TrimSpace(s.Text())
+		// Clean up tabs and newlines in btnText
+		btnText = strings.Join(strings.Fields(btnText), " ")
+		if epNum != "" {
+			return fmt.Sprintf("Episódio %s - %s", epNum, btnText)
+		}
+		return btnText
+	}
+
+	// Strategy 2: Previous sibling span with class "botao_dublado" (RedeTorrent)
+	prevSpan := s.PrevAllFiltered("span.botao_dublado").First()
+	if prevSpan.Length() > 0 {
+		context = strings.TrimSpace(prevSpan.Text())
+		if context != "" {
+			return context
+		}
+	}
+
+	// Strategy 3: Find the closest block container
+	parent := s.Closest("p, center, div, td, li")
+	if parent.Length() > 0 {
+		magnetsInParent := parent.Find("a[href^=\"magnet\"]")
+		
+		adwareHosts := []string{"seuvideo.xyz", "systemads.org", "superadsgo.xyz", "systemads.xyz", "receber.php", "get.php"}
+		adwareCount := 0
+		parent.Find("a[href]").Each(func(_ int, as *goquery.Selection) {
+			href, _ := as.Attr("href")
+			for _, host := range adwareHosts {
+				if strings.Contains(href, host) {
+					adwareCount++
+					break
+				}
+			}
+		})
+		
+		// If there are multiple magnets or adware links in this block, we should extract the text
+		// immediately preceding THIS specific anchor (s), rather than all text in the parent.
+		if magnetsInParent.Length() > 1 || adwareCount > 1 {
+			var segments []string
+			var currentSegment strings.Builder
+			for node := parent.Nodes[0].FirstChild; node != nil; node = node.NextSibling {
+				if node == s.Nodes[0] {
+					break
+				}
+				if node.Type == html.ElementNode && node.Data == "a" {
+					text := strings.TrimSpace(currentSegment.String())
+					if text != "" {
+						segments = append(segments, text)
+					}
+					currentSegment.Reset()
+				} else {
+					var text string
+					if node.Type == html.TextNode {
+						text = strings.TrimSpace(node.Data)
+						if text == "|" || text == "-" {
+							text = ""
+						}
+					} else {
+						text = strings.TrimSpace(goquery.NewDocumentFromNode(node).Text())
+					}
+					if text != "" {
+						currentSegment.WriteString(text + " ")
+					}
+				}
+			}
+
+			lastSeg := strings.TrimSpace(currentSegment.String())
+			if lastSeg != "" {
+				segments = append(segments, lastSeg)
+			}
+
+			var res string
+			if len(segments) > 0 {
+				res = segments[len(segments)-1]
+			}
+			
+			prefix := strings.Replace(res, "SERVIDOR PARA DOWNLOAD", "", -1)
+			prefix = strings.TrimSpace(prefix)
+
+			if goquery.NodeName(parent) == "center" {
+				prevCenter := parent.PrevAllFiltered("center").First()
+				if prevCenter.Length() > 0 && prevCenter.Find("a").Length() == 0 {
+					prevText := strings.TrimSpace(prevCenter.Text())
+					prevText = strings.Replace(prevText, "SERVIDOR PARA DOWNLOAD", "", -1)
+					prevText = strings.TrimSpace(prevText)
+					if prevText != "" {
+						prefix = fmt.Sprintf("%s | %s", prevText, prefix)
+					}
+				}
+			}
+			
+			btnText := strings.TrimSpace(s.Text())
+			if prefix != "" {
+				if btnText != "" && btnText != "Magnet-Link" && btnText != "MAGNET-LINK" && btnText != "DOWNLOAD" && btnText != "Download" {
+					return fmt.Sprintf("%s | %s", prefix, btnText)
+				}
+				return prefix
+			}
+			return btnText
+		} else {
+				// Just one magnet in this paragraph/center. The text of the parent is a good context!
+				text := strings.TrimSpace(parent.Text())
+				
+				// clean up common button texts
+				btnText := strings.TrimSpace(s.Text())
+				if btnText != "" {
+					text = strings.Replace(text, btnText, "", -1)
+				}
+				text = strings.Replace(text, "SERVIDOR PARA DOWNLOAD", "", -1)
+				text = strings.Replace(text, "Magnet-Link", "", -1)
+				text = strings.Replace(text, "MAGNET-LINK", "", -1)
+				text = strings.Replace(text, "DOWNLOAD", "", -1)
+				text = strings.Replace(text, "Download", "", -1)
+				text = strings.Replace(text, "–", "", -1)
+				text = strings.Replace(text, "|", "", -1)
+				
+				// Clean up extra spaces
+				text = strings.Join(strings.Fields(text), " ")
+
+				if text == "" {
+					prevBlock := parent.PrevAllFiltered("p, center, div").First()
+					if prevBlock.Length() > 0 {
+						text = strings.TrimSpace(prevBlock.Text())
+						text = strings.Replace(text, "SERVIDOR PARA DOWNLOAD", "", -1)
+						text = strings.Replace(text, "Magnet-Link", "", -1)
+						text = strings.Replace(text, "MAGNET-LINK", "", -1)
+						text = strings.Replace(text, "DOWNLOAD", "", -1)
+						text = strings.Replace(text, "Download", "", -1)
+						text = strings.Replace(text, "–", "", -1)
+						text = strings.Replace(text, "|", "", -1)
+						text = strings.Join(strings.Fields(text), " ")
+					}
+				}
+
+				// Also check if there is a previous <center> or <strong> for global title context
+				if goquery.NodeName(parent) == "center" {
+					prevCenter := parent.PrevAllFiltered("center").First()
+					if prevCenter.Length() > 0 && prevCenter.Find("a").Length() == 0 {
+						prevText := strings.TrimSpace(prevCenter.Text())
+						if prevText != "" {
+							text = fmt.Sprintf("%s | %s", prevText, text)
+						}
+					}
+				}
+
+				if btnText != "" && btnText != "Magnet-Link" && btnText != "MAGNET-LINK" && btnText != "DOWNLOAD" && btnText != "Download" {
+					text = fmt.Sprintf("%s | %s", text, btnText)
+				}
+
+				return strings.TrimSpace(text)
+			}
+		}
+
+	return ""
 }

--- a/api/index.go
+++ b/api/index.go
@@ -3,6 +3,9 @@ package handler
 import (
 	"encoding/json"
 	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
 	"time"
 
 	"github.com/felipemarinho97/torrent-indexer/cache"
@@ -42,10 +45,12 @@ type PostProcessorFunc func(*Indexer, *http.Request, []schema.IndexedTorrent) []
 var GlobalPostProcessors = []PostProcessorFunc{
 	AddSimilarityCheck,     // Jaccard similarity
 	FullfilMissingMetadata, // Fill missing size or title metadata
+	ParseTitleMetadata,     // Parse S/E, Resolution, Quality from titles
 	CleanupTitleWebsites,   // Remove website names from titles
 	FallbackPostTitle,      // Fallback to original title if empty
 	AppendAudioTags,        // Add (brazilian, eng, etc.) audio tags to titles
 	ApplySorting,           // Sort results based on sortBy and sortDirection params
+	StripExtendedMetadata,  // Strip metadata if ENABLE_EXTENDED_METADATA is not true
 	SendToSearchIndexer,    // Send indexed torrents to Meilisearch
 	FilterBy,               // Filter results based on query params (audio, etc.)
 	ApplyLimit,             // Limit number of results based on query param
@@ -74,7 +79,26 @@ func NewIndexers(
 	}
 }
 
-func HandlerIndex(w http.ResponseWriter, r *http.Request) {
+func (i *Indexer) GetAllHandlersMap() map[string]http.HandlerFunc {
+	return map[string]http.HandlerFunc{
+		"bludv":              i.HandlerBluDVIndexer,
+		"comando_torrents":   i.HandlerComandoIndexer,
+		"rede_torrent":       i.HandlerRedeTorrentIndexer,
+		"starck-filmes":      i.HandlerStarckFilmesIndexer,
+		"torrent-dos-filmes": i.HandlerTorrentDosFilmesIndexer,
+		"vaca_torrent":       i.HandlerVacaTorrentIndexer,
+	}
+}
+
+func (i *Indexer) GetIndexerNames() []string {
+	var names []string
+	for name := range i.GetAllHandlersMap() {
+		names = append(names, name)
+	}
+	return names
+}
+
+func (i *Indexer) HandlerIndex(w http.ResponseWriter, r *http.Request) {
 	currentTime := time.Now().Format(time.RFC850)
 
 	commonQueryParams := map[string]string{
@@ -115,21 +139,26 @@ func HandlerIndex(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusOK)
 	err := json.NewEncoder(w).Encode(RootResponse{
 		Time:  currentTime,
-		Build: consts.GetBuildInfo(),
-		IndexerNames: []string{
-			"comando_torrents",
-			"bludv",
-			"torrent-dos-filmes",
-			"filme_torrent",
-			"rede_torrent",
-			"vaca_torrent",
-			"starck-filmes",
-		},
+		Build:        consts.GetBuildInfo(),
+		IndexerNames: i.GetIndexerNames(),
 		Endpoints: Endpoints{
 			IndexerGeneric: []EndpointDetail{
 				{
 					Method:      "GET",
-					Description: "Indexer expoint for the specified indexer",
+					Description: "Indexer endpoint for the specified indexer. Supports multiple queries (e.g. ?q=q1&q=q2)",
+					QueryParams: commonQueryParams,
+				},
+				{
+					Method:      "GET",
+					Description: "Search across multiple specific indexers concurrently. Supports multiple queries.",
+					QueryParams: map[string]string{
+						"indexers": "comma-separated list of indexers (e.g. bludv,vaca_torrent)",
+						"q":        "search query (supports multiple)",
+					},
+				},
+				{
+					Method:      "GET",
+					Description: "Search across ALL indexers concurrently. Supports multiple queries.",
 					QueryParams: commonQueryParams,
 				},
 			},
@@ -148,12 +177,20 @@ func HandlerIndex(w http.ResponseWriter, r *http.Request) {
 			},
 			Search: []EndpointDetail{
 				{
-					Method:      "GET",
-					Description: "Search for cached torrents across all indexers",
+					Method:      "GET/POST",
+					Description: "Search for cached torrents across all indexers (Meilisearch). Supports multiple queries via GET ?q=a&q=b or POST {'queries':['a','b']}",
 					QueryParams: map[string]string{
-						"q":     "search query",
+						"q":     "search query (can pass multiple for multi-search)",
 						"limit": "maximum number of results to return (default: 10)",
 					},
+					Body: map[string]interface{}{
+						"queries": "array of string queries",
+						"limit":   "maximum results per query",
+					},
+				},
+				{
+					Method:      "GET",
+					Description: "Get statistics about the Meilisearch index",
 				},
 			},
 			UI: []EndpointDetail{
@@ -166,5 +203,149 @@ func HandlerIndex(w http.ResponseWriter, r *http.Request) {
 	})
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
+	}
+}
+
+func (i *Indexer) getIndexerHandlers(names []string) []http.HandlerFunc {
+	allHandlers := i.GetAllHandlersMap()
+
+	if len(names) == 0 {
+		return nil
+	}
+
+	var handlers []http.HandlerFunc
+	for _, name := range names {
+		if name == "all" {
+			handlers = make([]http.HandlerFunc, 0, len(allHandlers))
+			for _, h := range allHandlers {
+				handlers = append(handlers, h)
+			}
+			return handlers
+		}
+		if h, ok := allHandlers[name]; ok {
+			handlers = append(handlers, h)
+		}
+	}
+	return handlers
+}
+
+func (i *Indexer) HandlerMultiIndexers(w http.ResponseWriter, r *http.Request) {
+	var names []string
+	if r.URL.Path == "/indexers/all" {
+		names = []string{"all"}
+	} else {
+		namesParam := r.URL.Query().Get("indexers")
+		if namesParam != "" {
+			importStrings := strings.Split(namesParam, ",")
+			for _, name := range importStrings {
+				names = append(names, strings.TrimSpace(name))
+			}
+		}
+	}
+
+	handlers := i.getIndexerHandlers(names)
+	if len(handlers) == 0 {
+		http.Error(w, "No valid indexers specified", http.StatusBadRequest)
+		return
+	}
+
+	var wg sync.WaitGroup
+	var mu sync.Mutex
+	allResults := []schema.IndexedTorrent{}
+	totalIndexed := 0
+
+	for _, h := range handlers {
+		wg.Add(1)
+		go func(handlerFunc http.HandlerFunc) {
+			defer wg.Done()
+			rec := httptest.NewRecorder()
+			handlerFunc(rec, r)
+
+			if rec.Code == http.StatusOK {
+				var res Response
+				if err := json.Unmarshal(rec.Body.Bytes(), &res); err == nil {
+					mu.Lock()
+					allResults = append(allResults, res.Results...)
+					totalIndexed += res.IndexedCount
+					mu.Unlock()
+				}
+			}
+		}(h)
+	}
+
+	wg.Wait()
+
+	response := Response{
+		Results:      allResults,
+		Count:        len(allResults),
+		IndexedCount: totalIndexed,
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(response)
+}
+
+// WithMultiQuery wraps an http.HandlerFunc to support multiple 'q' query parameters.
+// If multiple 'q' parameters are present, it executes the handler concurrently for each query
+// and merges the results into a single response.
+func WithMultiQuery(handlerFunc http.HandlerFunc) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		queries := r.URL.Query()["q"]
+		if len(queries) <= 1 {
+			// Standard execution if 0 or 1 query
+			handlerFunc(w, r)
+			return
+		}
+
+		var wg sync.WaitGroup
+		var mu sync.Mutex
+		allResults := []schema.IndexedTorrent{}
+		totalIndexed := 0
+		status := http.StatusOK
+
+		for _, q := range queries {
+			wg.Add(1)
+			go func(query string) {
+				defer wg.Done()
+
+				// Create a new request with just this one 'q'
+				newURL := *r.URL
+				newQuery := newURL.Query()
+				newQuery.Set("q", query)
+				newURL.RawQuery = newQuery.Encode()
+
+				newReq := r.Clone(r.Context())
+				newReq.URL = &newURL
+
+				rec := httptest.NewRecorder()
+				handlerFunc(rec, newReq)
+
+				if rec.Code == http.StatusOK {
+					var res Response
+					if err := json.Unmarshal(rec.Body.Bytes(), &res); err == nil {
+						mu.Lock()
+						allResults = append(allResults, res.Results...)
+						totalIndexed += res.IndexedCount
+						mu.Unlock()
+					}
+				} else {
+					mu.Lock()
+					status = rec.Code
+					mu.Unlock()
+				}
+			}(q)
+		}
+
+		wg.Wait()
+
+		response := Response{
+			Results:      allResults,
+			Count:        len(allResults),
+			IndexedCount: totalIndexed,
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(status)
+		json.NewEncoder(w).Encode(response)
 	}
 }

--- a/api/index.go
+++ b/api/index.go
@@ -58,6 +58,7 @@ var GlobalPostProcessors = []PostProcessorFunc{
 
 type IndexersConfig struct {
 	FallbackTitleEnabled bool
+	DisabledIndexers     map[string]bool
 }
 
 func NewIndexers(
@@ -80,7 +81,7 @@ func NewIndexers(
 }
 
 func (i *Indexer) GetAllHandlersMap() map[string]http.HandlerFunc {
-	return map[string]http.HandlerFunc{
+	allHandlers := map[string]http.HandlerFunc{
 		"bludv":              i.HandlerBluDVIndexer,
 		"comando_torrents":   i.HandlerComandoIndexer,
 		"rede_torrent":       i.HandlerRedeTorrentIndexer,
@@ -88,6 +89,14 @@ func (i *Indexer) GetAllHandlersMap() map[string]http.HandlerFunc {
 		"torrent-dos-filmes": i.HandlerTorrentDosFilmesIndexer,
 		"vaca_torrent":       i.HandlerVacaTorrentIndexer,
 	}
+
+	filteredHandlers := make(map[string]http.HandlerFunc)
+	for name, handler := range allHandlers {
+		if !i.config.DisabledIndexers[name] {
+			filteredHandlers[name] = handler
+		}
+	}
+	return filteredHandlers
 }
 
 func (i *Indexer) GetIndexerNames() []string {

--- a/api/post_processors.go
+++ b/api/post_processors.go
@@ -3,11 +3,14 @@ package handler
 import (
 	"fmt"
 	"net/http"
+	"os"
+	"regexp"
 	"slices"
 	"strconv"
 	"strings"
 
 	"github.com/felipemarinho97/torrent-indexer/logging"
+	"github.com/felipemarinho97/torrent-indexer/magnet"
 	"github.com/felipemarinho97/torrent-indexer/schema"
 	"github.com/felipemarinho97/torrent-indexer/utils"
 	"github.com/hbollon/go-edlib"
@@ -60,37 +63,35 @@ func FullfilMissingMetadata(i *Indexer, r *http.Request, torrents []schema.Index
 	}
 
 	return utils.ParallelFlatMap(torrents, func(it schema.IndexedTorrent) ([]schema.IndexedTorrent, error) {
-		if it.Size != "" && it.Title != "" && it.OriginalTitle != "" {
-			return []schema.IndexedTorrent{it}, nil
-		}
-		m, err := i.magnetMetadataAPI.FetchMetadata(r.Context(), it.MagnetLink)
-		if err != nil {
-			return []schema.IndexedTorrent{it}, nil
-		}
-
-		// convert size in bytes to a human-readable format
-		it.Size = utils.FormatBytes(m.Size)
-
-		// Use name from metadata if available as it is more accurate
-		if m.Name != "" {
-			it.Title = m.Name
-		}
-		logging.Debug().Str("info_hash", m.InfoHash).Str("size", it.Size).Msg("Retrieved metadata from MagnetMetadataAPI")
-
-		// If files are present, add them to the indexed torrent
-		if len(m.Files) > 0 {
-			it.Files = make([]schema.File, len(m.Files))
-			for i, file := range m.Files {
-				it.Files[i] = schema.File{
-					Path: file.Path,
-					Size: utils.FormatBytes(file.Size),
+		populateFromMetadata := func(m *magnet.MetadataResponse) {
+			if it.Size == "" {
+				it.Size = utils.FormatBytes(m.Size)
+			}
+			if it.Title == "" && m.Name != "" {
+				it.Title = m.Name
+			}
+			if len(m.Files) > 0 {
+				it.Files = make([]schema.File, len(m.Files))
+				for i, file := range m.Files {
+					it.Files[i] = schema.File{
+						Path: file.Path,
+						Size: utils.FormatBytes(file.Size),
+					}
 				}
+			}
+			if it.Date.IsZero() {
+				it.Date = m.CreatedAt
 			}
 		}
 
-		// If "date" is zero, use the date from metadata if available
-		if it.Date.IsZero() {
-			it.Date = m.CreatedAt
+		if m := i.magnetMetadataAPI.GetCachedMetadata(r.Context(), it.InfoHash); m != nil {
+			populateFromMetadata(m)
+		} else if it.Size == "" || it.Title == "" || it.OriginalTitle == "" {
+			m, err := i.magnetMetadataAPI.FetchMetadata(r.Context(), it.MagnetLink)
+			if err == nil {
+				logging.Debug().Str("info_hash", m.InfoHash).Str("size", it.Size).Msg("Retrieved metadata from MagnetMetadataAPI")
+				populateFromMetadata(m)
+			}
 		}
 
 		return []schema.IndexedTorrent{it}, nil
@@ -279,4 +280,48 @@ func FilterBy(_ *Indexer, r *http.Request, torrents []schema.IndexedTorrent) []s
 
 		return true
 	})
+}
+
+// StripExtendedMetadata removes extended metadata fields if the user has not explicitly enabled them.
+func StripExtendedMetadata(_ *Indexer, _ *http.Request, torrents []schema.IndexedTorrent) []schema.IndexedTorrent {
+	if os.Getenv("ENABLE_EXTENDED_METADATA") == "true" {
+		return torrents
+	}
+
+	for i := range torrents {
+		torrents[i].Genres = nil
+		torrents[i].Subtitles = nil
+		torrents[i].Duration = ""
+		torrents[i].Classification = ""
+		torrents[i].Quality = ""
+		torrents[i].VideoQuality = ""
+		torrents[i].AudioQuality = ""
+		torrents[i].Files = nil
+		torrents[i].Similarity = 0
+		// Note: We leave 'Context' intact as it is small and universally useful.
+	}
+
+	return torrents
+}
+
+// ParseTitleMetadata extracts metadata from the title (like Resolution and Quality) if they are missing
+func ParseTitleMetadata(_ *Indexer, _ *http.Request, torrents []schema.IndexedTorrent) []schema.IndexedTorrent {
+	resRegex := regexp.MustCompile(`(?i)(1080p|720p|2160p|4K|1080|720)`)
+	qualRegex := regexp.MustCompile(`(?i)(WEB-DL|WEBRip|BluRay|HDTV|CAM|TS)`)
+
+	for i, t := range torrents {
+		// Attempt to extract resolution from Title
+		if t.VideoQuality == "" {
+			if match := resRegex.FindStringSubmatch(t.Title); len(match) > 0 {
+				torrents[i].VideoQuality = strings.ToUpper(match[1])
+			}
+		}
+		// Attempt to extract quality from Title
+		if t.Quality == "" {
+			if match := qualRegex.FindStringSubmatch(t.Title); len(match) > 0 {
+				torrents[i].Quality = strings.ToUpper(match[1])
+			}
+		}
+	}
+	return torrents
 }

--- a/api/rede_torrent.go
+++ b/api/rede_torrent.go
@@ -115,22 +115,30 @@ func getTorrentsRedeTorrent(ctx context.Context, i *Indexer, link, referer strin
 	}
 
 	article := doc.Find(".conteudo")
-	// title pattern: "Something - optional balbla (dddd) some shit" - extract "Something" and "dddd"
-	titleRe := regexp.MustCompile(`^(.*?)(?: - (.*?))? \((\d{4})\)`)
-	titleP := titleRe.FindStringSubmatch(article.Find("h1").Text())
-	if len(titleP) < 3 {
+	rawTitle := strings.TrimSpace(article.Find("h1").Text())
+	if rawTitle == "" {
 		return nil, fmt.Errorf("could not extract title from %s", link)
 	}
-	title := strings.TrimSpace(titleP[1])
-	year := strings.TrimSpace(titleP[3])
+	title := rawTitle
+	year := ""
+	
+	titleRe := regexp.MustCompile(`^(.*?)(?: - (.*?))? \((\d{4})\)`)
+	titleP := titleRe.FindStringSubmatch(rawTitle)
+	if len(titleP) >= 4 {
+		title = strings.TrimSpace(titleP[1])
+		year = strings.TrimSpace(titleP[3])
+	} else if len(titleP) >= 2 {
+		title = strings.TrimSpace(titleP[1])
+	}
 
 	textContent := article.Find(".apenas_itemprop")
 	date := getPublishedDateFromMeta(doc)
 	magnets := textContent.Find("a[href^=\"magnet\"]")
-	var magnetLinks []string
+	var magnetLinks []ExtractedMagnet
 	magnets.Each(func(i int, s *goquery.Selection) {
 		magnetLink, _ := s.Attr("href")
-		magnetLinks = append(magnetLinks, magnetLink)
+		ctxStr := ExtractMagnetContext(s)
+		magnetLinks = append(magnetLinks, ExtractedMagnet{Link: magnetLink, Context: ctxStr})
 	})
 
 	var audio []schema.Audio
@@ -196,14 +204,15 @@ func getTorrentsRedeTorrent(ctx context.Context, i *Indexer, link, referer strin
 		}
 	})
 
-	size = utils.StableUniq(size)
+	// size = utils.StableUniq(size) // Fixed bug: do not deduplicate sizes
 
 	var chanIndexedTorrent = make(chan schema.IndexedTorrent)
 
 	// for each magnet link, create a new indexed torrent
-	for it, magnetLink := range magnetLinks {
+	for it, magnetInfo := range magnetLinks {
 		it := it
-		go func(it int, magnetLink string) {
+		go func(it int, magnetInfo ExtractedMagnet) {
+			magnetLink := magnetInfo.Link
 			magnet, err := magnet.ParseMagnetUri(magnetLink)
 			if err != nil {
 				logging.Error().Err(err).Str("magnet_link", magnetLink).Msg("Failed to parse magnet URI")
@@ -219,11 +228,22 @@ func getTorrentsRedeTorrent(ctx context.Context, i *Indexer, link, referer strin
 			}
 
 			title := processTitle(title, magnetAudio)
+			
+			var ctxCln string
+			if magnetInfo.Context != "" {
+				ctxCln = strings.TrimSpace(magnetInfo.Context)
+			}
 
 			// if the number of sizes is equal to the number of magnets, then assign the size to each indexed torrent in order
 			var mySize string
 			if len(size) == len(magnetLinks) {
 				mySize = size[it]
+			} else if len(size) > 0 {
+				if it < len(size) {
+					mySize = size[it]
+				} else {
+					mySize = size[0]
+				}
 			}
 			if mySize == "" {
 				go func() {
@@ -245,9 +265,28 @@ func getTorrentsRedeTorrent(ctx context.Context, i *Indexer, link, referer strin
 				LeechCount:    peer,
 				SeedCount:     seed,
 				Size:          mySize,
+				Context:       ctxCln,
 			}
+			
+			// Pass raw texts collected earlier to extract advanced Betor metadata
+			var allText strings.Builder
+			article.Find("div#informacoes > p").Each(func(i int, s *goquery.Selection) {
+				htmlContent, _ := s.Html()
+				htmlContent = strings.ReplaceAll(htmlContent, "\n", "")
+				htmlContent = strings.ReplaceAll(htmlContent, "\t", "")
+				brRe := regexp.MustCompile(`<br\s*\/?>`)
+				htmlContent = brRe.ReplaceAllString(htmlContent, "<br>")
+				lines := strings.Split(htmlContent, "<br>")
+				for _, line := range lines {
+					re := regexp.MustCompile(`<[^>]*>`)
+					line = re.ReplaceAllString(line, "")
+					allText.WriteString(strings.TrimSpace(line) + "\n")
+				}
+			})
+			extractExtendedMetadata(allText.String(), &ixt)
+			
 			chanIndexedTorrent <- ixt
-		}(it, magnetLink)
+		}(it, magnetInfo)
 	}
 
 	for i := 0; i < len(magnetLinks); i++ {

--- a/api/search.go
+++ b/api/search.go
@@ -6,6 +6,7 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/felipemarinho97/torrent-indexer/schema"
 	meilisearch "github.com/felipemarinho97/torrent-indexer/search"
 )
 
@@ -36,39 +37,60 @@ func NewMeilisearchHandler(module *meilisearch.SearchIndexer) *MeilisearchHandle
 	return &MeilisearchHandler{Module: module}
 }
 
+// MultiSearchRequest represents the request body for multiple searches
+type MultiSearchRequest struct {
+	Queries []string `json:"queries"`
+	Limit   int      `json:"limit,omitempty"`
+}
+
 // SearchTorrentHandler handles the searching of torrent items.
 func (h *MeilisearchHandler) SearchTorrentHandler(w http.ResponseWriter, r *http.Request) {
-	if r.Method != http.MethodGet {
+	if r.Method != http.MethodGet && r.Method != http.MethodPost {
 		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
 		return
 	}
 
-	query := r.URL.Query().Get("q")
-	if query == "" {
-		query = time.Now().Format("2006-01-02") // needed for prowlar/jackett empty queries
-	}
+	var queries []string
+	limit := 10
 
-	limitStr := r.URL.Query().Get("limit")
-	limit := 10 // Default limit
-	if limitStr != "" {
-		var err error
-		limit, err = strconv.Atoi(limitStr)
-		if err != nil || limit <= 0 {
-			http.Error(w, "Invalid limit parameter", http.StatusBadRequest)
+	if r.Method == http.MethodGet {
+		queries = r.URL.Query()["q"]
+		if len(queries) == 0 {
+			// needed for prowlar/jackett empty queries
+			queries = []string{time.Now().Format("2006-01-02")}
+		}
+		if limitStr := r.URL.Query().Get("limit"); limitStr != "" {
+			if l, err := strconv.Atoi(limitStr); err == nil && l > 0 {
+				limit = l
+			}
+		}
+	} else if r.Method == http.MethodPost {
+		var req MultiSearchRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			http.Error(w, "Invalid request body", http.StatusBadRequest)
 			return
+		}
+		queries = req.Queries
+		if req.Limit > 0 {
+			limit = req.Limit
 		}
 	}
 
-	results, err := h.Module.SearchTorrent(query, limit)
+	allResultsArrays, err := h.Module.MultiSearchTorrent(queries, limit)
 	if err != nil {
-		http.Error(w, "Failed to search torrents", http.StatusInternalServerError)
+		http.Error(w, "Failed to perform search", http.StatusInternalServerError)
 		return
+	}
+
+	var allResults []schema.IndexedTorrent
+	for _, results := range allResultsArrays {
+		allResults = append(allResults, results...)
 	}
 
 	// Format response to match indexers structure
 	response := map[string]interface{}{
-		"results": results,
-		"count":   len(results),
+		"results": allResults,
+		"count":   len(allResults),
 	}
 
 	w.Header().Set("Content-Type", "application/json")

--- a/api/search.go
+++ b/api/search.go
@@ -41,53 +41,85 @@ func NewMeilisearchHandler(module *meilisearch.SearchIndexer) *MeilisearchHandle
 }
 
 // SearchTorrentHandler handles the searching of torrent items.
+// Supports multiple queries via GET ?q=a&q=b (each limited to perQueryLimit).
 func (h *MeilisearchHandler) SearchTorrentHandler(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
 		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
 		return
 	}
 
-	query := r.URL.Query().Get("q")
-	if query == "" {
-		query = time.Now().Format("2006-01-02") // needed for prowlar/jackett empty queries
+	queries := r.URL.Query()["q"]
+	if len(queries) == 0 || (len(queries) == 1 && queries[0] == "") {
+		queries = []string{time.Now().Format("2006-01-02")} // needed for prowlar/jackett empty queries
 	}
 
 	limitStr := r.URL.Query().Get("limit")
-	limit := 100 // Default limit per query
+	perQueryLimit := 100 // Default limit per query
 	if limitStr != "" {
 		var err error
-		limit, err = strconv.Atoi(limitStr)
-		if err != nil || limit <= 0 {
+		perQueryLimit, err = strconv.Atoi(limitStr)
+		if err != nil || perQueryLimit <= 0 {
 			http.Error(w, "Invalid limit parameter", http.StatusBadRequest)
 			return
 		}
 	}
 
 	// Cap at 100 per query to prevent abuse
-	if limit > 100 {
-		limit = 100
+	if perQueryLimit > 100 {
+		perQueryLimit = 100
 	}
 
-	results, err := h.Module.SearchTorrent(query, limit)
-	if err != nil {
-		http.Error(w, "Failed to search torrents", http.StatusInternalServerError)
-		return
+	// Search each query with the per-query limit, then merge + deduplicate
+	seen := make(map[string]bool)
+	var allResults []schema.IndexedTorrent
+
+	for _, query := range queries {
+		query = strings.TrimSpace(query)
+		if query == "" {
+			continue
+		}
+
+		results, err := h.Module.SearchTorrent(query, perQueryLimit)
+		if err != nil {
+			continue
+		}
+
+		// Calculate similarity scores against this specific query
+		qLower := strings.ToLower(query)
+		for i := range results {
+			tLower := strings.ToLower(results[i].Title)
+			sim := edlib.JaccardSimilarity(tLower, qLower, 2)
+			// Keep the highest similarity if we see the same torrent from multiple queries
+			if results[i].Similarity < sim {
+				results[i].Similarity = sim
+			}
+		}
+
+		// Deduplicate by info_hash
+		for _, r := range results {
+			key := r.InfoHash
+			if key == "" {
+				key = r.MagnetLink
+			}
+			if key != "" && seen[key] {
+				continue
+			}
+			if key != "" {
+				seen[key] = true
+			}
+			allResults = append(allResults, r)
+		}
 	}
 
-	// Calculate similarity scores and sort by highest similarity first
-	qLower := strings.ToLower(query)
-	for i := range results {
-		tLower := strings.ToLower(results[i].Title)
-		results[i].Similarity = edlib.JaccardSimilarity(tLower, qLower, 2)
-	}
-	slices.SortFunc(results, func(a, b schema.IndexedTorrent) int {
+	// Sort all merged results by highest similarity first
+	slices.SortFunc(allResults, func(a, b schema.IndexedTorrent) int {
 		return int((b.Similarity - a.Similarity) * 1000000)
 	})
 
 	// Format response to match indexers structure
 	response := map[string]interface{}{
-		"results": results,
-		"count":   len(results),
+		"results": allResults,
+		"count":   len(allResults),
 	}
 
 	w.Header().Set("Content-Type", "application/json")

--- a/api/search.go
+++ b/api/search.go
@@ -3,9 +3,12 @@ package handler
 import (
 	"encoding/json"
 	"net/http"
+	"slices"
 	"strconv"
+	"strings"
 	"time"
 
+	edlib "github.com/hbollon/go-edlib"
 	"github.com/felipemarinho97/torrent-indexer/schema"
 	meilisearch "github.com/felipemarinho97/torrent-indexer/search"
 )
@@ -37,60 +40,54 @@ func NewMeilisearchHandler(module *meilisearch.SearchIndexer) *MeilisearchHandle
 	return &MeilisearchHandler{Module: module}
 }
 
-// MultiSearchRequest represents the request body for multiple searches
-type MultiSearchRequest struct {
-	Queries []string `json:"queries"`
-	Limit   int      `json:"limit,omitempty"`
-}
-
 // SearchTorrentHandler handles the searching of torrent items.
 func (h *MeilisearchHandler) SearchTorrentHandler(w http.ResponseWriter, r *http.Request) {
-	if r.Method != http.MethodGet && r.Method != http.MethodPost {
+	if r.Method != http.MethodGet {
 		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
 		return
 	}
 
-	var queries []string
-	limit := 10
+	query := r.URL.Query().Get("q")
+	if query == "" {
+		query = time.Now().Format("2006-01-02") // needed for prowlar/jackett empty queries
+	}
 
-	if r.Method == http.MethodGet {
-		queries = r.URL.Query()["q"]
-		if len(queries) == 0 {
-			// needed for prowlar/jackett empty queries
-			queries = []string{time.Now().Format("2006-01-02")}
-		}
-		if limitStr := r.URL.Query().Get("limit"); limitStr != "" {
-			if l, err := strconv.Atoi(limitStr); err == nil && l > 0 {
-				limit = l
-			}
-		}
-	} else if r.Method == http.MethodPost {
-		var req MultiSearchRequest
-		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-			http.Error(w, "Invalid request body", http.StatusBadRequest)
+	limitStr := r.URL.Query().Get("limit")
+	limit := 100 // Default limit per query
+	if limitStr != "" {
+		var err error
+		limit, err = strconv.Atoi(limitStr)
+		if err != nil || limit <= 0 {
+			http.Error(w, "Invalid limit parameter", http.StatusBadRequest)
 			return
-		}
-		queries = req.Queries
-		if req.Limit > 0 {
-			limit = req.Limit
 		}
 	}
 
-	allResultsArrays, err := h.Module.MultiSearchTorrent(queries, limit)
+	// Cap at 100 per query to prevent abuse
+	if limit > 100 {
+		limit = 100
+	}
+
+	results, err := h.Module.SearchTorrent(query, limit)
 	if err != nil {
-		http.Error(w, "Failed to perform search", http.StatusInternalServerError)
+		http.Error(w, "Failed to search torrents", http.StatusInternalServerError)
 		return
 	}
 
-	var allResults []schema.IndexedTorrent
-	for _, results := range allResultsArrays {
-		allResults = append(allResults, results...)
+	// Calculate similarity scores and sort by highest similarity first
+	qLower := strings.ToLower(query)
+	for i := range results {
+		tLower := strings.ToLower(results[i].Title)
+		results[i].Similarity = edlib.JaccardSimilarity(tLower, qLower, 2)
 	}
+	slices.SortFunc(results, func(a, b schema.IndexedTorrent) int {
+		return int((b.Similarity - a.Similarity) * 1000000)
+	})
 
 	// Format response to match indexers structure
 	response := map[string]interface{}{
-		"results": allResults,
-		"count":   len(allResults),
+		"results": results,
+		"count":   len(results),
 	}
 
 	w.Header().Set("Content-Type", "application/json")

--- a/api/starck_filmes.go
+++ b/api/starck_filmes.go
@@ -126,25 +126,28 @@ func getTorrentStarckFilmes(ctx context.Context, i *Indexer, link, referer strin
 	title := capa.Find(".post-description > h2").Text()
 	post_buttons := post.Find(".post-buttons")
 	magnets := post_buttons.Find("a[href^=\"magnet\"]")
-	var magnetLinks []string
+	var magnetLinks []ExtractedMagnet
 	magnets.Each(func(i int, s *goquery.Selection) {
 		magnetLink, _ := s.Attr("href")
-		magnetLinks = append(magnetLinks, magnetLink)
+		ctxStr := ExtractMagnetContext(s)
+		magnetLinks = append(magnetLinks, ExtractedMagnet{Link: magnetLink, Context: ctxStr})
 	})
 	dataUs := post_buttons.Find("a[data-u]")
 	dataUs.Each(func(i int, s *goquery.Selection) {
 		dataU, _ := s.Attr("data-u")
 		magnetLink, err := utils.DecodeStarckDataU(dataU)
+		ctxStr := ExtractMagnetContext(s)
 		if err != nil {
 			logging.Warn().Err(err).Str("data_u", dataU).Msg("Failed to decode data-u attribute, skipping")
 			return
 		}
-		magnetLinks = append(magnetLinks, magnetLink)
+		magnetLinks = append(magnetLinks, ExtractedMagnet{Link: magnetLink, Context: ctxStr})
 	})
 
 	var audio []schema.Audio
 	var year string
 	var size []string
+	var allText strings.Builder
 	capa.Find(".post-description p").Each(func(i int, s *goquery.Selection) {
 		// pattern:
 		// Nome Original: 28 Weeks Later
@@ -162,25 +165,30 @@ func getTorrentStarckFilmes(ctx context.Context, i *Indexer, link, referer strin
 			text.WriteString(span.Text())
 			text.WriteString(" ")
 		})
-		audio = append(audio, findAudioFromText(text.String())...)
-		y := findYearFromText(text.String(), title)
+		
+		textStr := text.String()
+		allText.WriteString(textStr + "\n")
+		
+		audio = append(audio, findAudioFromText(textStr)...)
+		y := findYearFromText(textStr, title)
 		if y != "" {
 			year = y
 		}
-		size = append(size, findSizesFromText(text.String())...)
+		size = append(size, findSizesFromText(textStr)...)
 	})
 
 	// TODO: find any link from imdb
 	imdbLink := ""
 
-	size = utils.StableUniq(size)
+	// size = utils.StableUniq(size) // Fixed bug: do not deduplicate sizes
 
 	var chanIndexedTorrent = make(chan schema.IndexedTorrent)
 
 	// for each magnet link, create a new indexed torrent
-	for it, magnetLink := range magnetLinks {
+	for it, magnetInfo := range magnetLinks {
 		it := it
-		go func(it int, magnetLink string) {
+		go func(it int, magnetInfo ExtractedMagnet) {
+			magnetLink := magnetInfo.Link
 			magnet, err := magnet.ParseMagnetUri(magnetLink)
 			if err != nil {
 				logging.Error().Err(err).Str("magnet_link", magnetLink).Msg("Failed to parse magnet URI")
@@ -209,11 +217,22 @@ func getTorrentStarckFilmes(ctx context.Context, i *Indexer, link, referer strin
 			}
 
 			title := processTitle(title, magnetAudio)
+			
+			var ctxCln string
+			if magnetInfo.Context != "" {
+				ctxCln = strings.TrimSpace(magnetInfo.Context)
+			}
 
 			// if the number of sizes is equal to the number of magnets, then assign the size to each indexed torrent in order
 			var mySize string
 			if len(size) == len(magnetLinks) {
 				mySize = size[it]
+			} else if len(size) > 0 {
+				if it < len(size) {
+					mySize = size[it]
+				} else {
+					mySize = size[0]
+				}
 			}
 			if mySize == "" {
 				go func() {
@@ -235,9 +254,13 @@ func getTorrentStarckFilmes(ctx context.Context, i *Indexer, link, referer strin
 				LeechCount:    peer,
 				SeedCount:     seed,
 				Size:          mySize,
+				Context:       ctxCln,
 			}
+			
+			extractExtendedMetadata(allText.String(), &ixt)
+			
 			chanIndexedTorrent <- ixt
-		}(it, magnetLink)
+		}(it, magnetInfo)
 	}
 
 	for i := 0; i < len(magnetLinks); i++ {

--- a/api/torrent_dos_filmes.go
+++ b/api/torrent_dos_filmes.go
@@ -118,15 +118,17 @@ func getTorrentsTorrentDosFilmes(ctx context.Context, i *Indexer, link, referer 
 	textContent := article.Find("div.content")
 	date := getPublishedDateFromMeta(doc)
 	magnets := textContent.Find("a[href^=\"magnet\"]")
-	var magnetLinks []string
+	var magnetLinks []ExtractedMagnet
 	magnets.Each(func(i int, s *goquery.Selection) {
 		magnetLink, _ := s.Attr("href")
-		magnetLinks = append(magnetLinks, magnetLink)
+		ctxStr := ExtractMagnetContext(s)
+		magnetLinks = append(magnetLinks, ExtractedMagnet{Link: magnetLink, Context: ctxStr})
 	})
 
 	var audio []schema.Audio
 	var year string
 	var size []string
+	var allText strings.Builder
 	article.Find("div.content p").Each(func(i int, s *goquery.Selection) {
 		// pattern:
 		// Título Traduzido: Fundação
@@ -145,6 +147,7 @@ func getTorrentsTorrentDosFilmes(ctx context.Context, i *Indexer, link, referer 
 		// Duração: 59 Min.
 		// Servidor: Torrent
 		text := s.Text()
+		allText.WriteString(text + "\n")
 
 		audio = append(audio, findAudioFromText(text)...)
 		y := findYearFromText(text, title)
@@ -164,14 +167,15 @@ func getTorrentsTorrentDosFilmes(ctx context.Context, i *Indexer, link, referer 
 		}
 	})
 
-	size = utils.StableUniq(size)
+	// size = utils.StableUniq(size) // Fixed bug: do not deduplicate sizes
 
 	var chanIndexedTorrent = make(chan schema.IndexedTorrent)
 
 	// for each magnet link, create a new indexed torrent
-	for it, magnetLink := range magnetLinks {
+	for it, magnetInfo := range magnetLinks {
 		it := it
-		go func(it int, magnetLink string) {
+		go func(it int, magnetInfo ExtractedMagnet) {
+			magnetLink := magnetInfo.Link
 			magnet, err := magnet.ParseMagnetUri(magnetLink)
 			if err != nil {
 				logging.Error().Err(err).Str("magnet_link", magnetLink).Msg("Failed to parse magnet URI")
@@ -187,11 +191,22 @@ func getTorrentsTorrentDosFilmes(ctx context.Context, i *Indexer, link, referer 
 			}
 
 			title := processTitle(title, magnetAudio)
+			
+			var ctxCln string
+			if magnetInfo.Context != "" {
+				ctxCln = strings.TrimSpace(magnetInfo.Context)
+			}
 
 			// if the number of sizes is equal to the number of magnets, then assign the size to each indexed torrent in order
 			var mySize string
 			if len(size) == len(magnetLinks) {
 				mySize = size[it]
+			} else if len(size) > 0 {
+				if it < len(size) {
+					mySize = size[it]
+				} else {
+					mySize = size[0]
+				}
 			}
 			if mySize == "" {
 				go func() {
@@ -213,9 +228,13 @@ func getTorrentsTorrentDosFilmes(ctx context.Context, i *Indexer, link, referer 
 				LeechCount:    peer,
 				SeedCount:     seed,
 				Size:          mySize,
+				Context:       ctxCln,
 			}
+			
+			extractExtendedMetadata(allText.String(), &ixt)
+			
 			chanIndexedTorrent <- ixt
-		}(it, magnetLink)
+		}(it, magnetInfo)
 	}
 
 	for i := 0; i < len(magnetLinks); i++ {

--- a/api/vaca_torrent.go
+++ b/api/vaca_torrent.go
@@ -249,10 +249,12 @@ func getTorrentsVacaTorrent(ctx context.Context, i *Indexer, link, referer strin
 	var date time.Time
 
 	date = getPublishedDateFromMeta(doc)
+	var allText strings.Builder
 
 	doc.Find(".col-left ul li, .content p").Each(func(_ int, s *goquery.Selection) {
 		text := s.Text()
 		html, _ := s.Html()
+		allText.WriteString(text + "\n")
 
 		// Extract Year
 		if year == "" {
@@ -300,10 +302,11 @@ func getTorrentsVacaTorrent(ctx context.Context, i *Indexer, link, referer strin
 	}
 
 	// Extract magnet links
-	var magnetLinks []string
+	var magnetLinks []ExtractedMagnet
 	doc.Find("a[href^=\"magnet\"]").Each(func(_ int, s *goquery.Selection) {
 		magnetLink, _ := s.Attr("href")
-		magnetLinks = append(magnetLinks, magnetLink)
+		ctxStr := ExtractMagnetContext(s)
+		magnetLinks = append(magnetLinks, ExtractedMagnet{Link: magnetLink, Context: ctxStr})
 	})
 
 	doc.Find(".area-links-download a").Each(func(_ int, s *goquery.Selection) {
@@ -316,8 +319,9 @@ func getTorrentsVacaTorrent(ctx context.Context, i *Indexer, link, referer strin
 				queryID := u.Query().Get("id")
 				if queryID != "" {
 					magnetLink, err := soraFetcher.FetchLink(ctx, queryID)
+					ctxStr := ExtractMagnetContext(s)
 					if err == nil && magnetLink != "" {
-						magnetLinks = append(magnetLinks, magnetLink)
+						magnetLinks = append(magnetLinks, ExtractedMagnet{Link: magnetLink, Context: ctxStr})
 					}
 				}
 			}
@@ -341,21 +345,23 @@ func getTorrentsVacaTorrent(ctx context.Context, i *Indexer, link, referer strin
 				if err == nil {
 					commentDoc.Find("a[href^=\"magnet\"]").Each(func(_ int, s *goquery.Selection) {
 						magnetLink, _ := s.Attr("href")
-						magnetLinks = append(magnetLinks, magnetLink)
+						ctxStr := ExtractMagnetContext(s)
+						magnetLinks = append(magnetLinks, ExtractedMagnet{Link: magnetLink, Context: ctxStr})
 					})
 				}
 			}
 		}
 	})
 
-	size = utils.StableUniq(size)
+	// size = utils.StableUniq(size) // Fixed bug: do not deduplicate sizes
 
 	var chanIndexedTorrent = make(chan schema.IndexedTorrent)
 
 	// for each magnet link, create a new indexed torrent
-	for it, magnetLink := range magnetLinks {
+	for it, magnetInfo := range magnetLinks {
 		it := it
-		go func(it int, magnetLink string) {
+		go func(it int, magnetInfo ExtractedMagnet) {
+			magnetLink := magnetInfo.Link
 			magnet, err := magnet.ParseMagnetUri(magnetLink)
 			if err != nil {
 				logging.Error().Err(err).Str("magnet_link", magnetLink).Msg("Failed to parse magnet URI")
@@ -373,11 +379,22 @@ func getTorrentsVacaTorrent(ctx context.Context, i *Indexer, link, referer strin
 			}
 
 			processedTitle := processVacaTorrentTitle(title, magnetAudio, season)
+			
+			var ctxCln string
+			if magnetInfo.Context != "" {
+				ctxCln = strings.TrimSpace(magnetInfo.Context)
+			}
 
 			// if the number of sizes is equal to the number of magnets, then assign the size to each indexed torrent in order
 			var mySize string
 			if len(size) == len(magnetLinks) {
 				mySize = size[it]
+			} else if len(size) > 0 {
+				if it < len(size) {
+					mySize = size[it]
+				} else {
+					mySize = size[0]
+				}
 			}
 			if mySize == "" {
 				go func() {
@@ -399,9 +416,13 @@ func getTorrentsVacaTorrent(ctx context.Context, i *Indexer, link, referer strin
 				LeechCount:    peer,
 				SeedCount:     seed,
 				Size:          mySize,
+				Context:       ctxCln,
 			}
+			
+			extractExtendedMetadata(allText.String(), &ixt)
+			
 			chanIndexedTorrent <- ixt
-		}(it, magnetLink)
+		}(it, magnetInfo)
 	}
 
 	for i := 0; i < len(magnetLinks); i++ {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,6 +22,9 @@ services:
       # - MAGNET_METADATA_API_ENABLED=false
       # - MAGNET_METADATA_API_ADDRESS=http://magnet-metadata-api:8080
       # - MAGNET_METADATA_API_TIMEOUT_SECONDS=10
+
+      ## Optional: Add extended metadata (duration, quality, genres, etc.) to search results
+      # - ENABLE_EXTENDED_METADATA=false
   
   redis:
     image: redis:alpine
@@ -55,7 +58,8 @@ services:
   #   restart: unless-stopped
   #   ports:
   #     - "8999:8080"
-  #     - "42069:42069"
+  #     - "42069:42069/tcp"
+  #     - "42069:42069/udp"
   #   networks:
   #     - indexer
   #   environment:

--- a/magnet/magnet_metadata_api.go
+++ b/magnet/magnet_metadata_api.go
@@ -69,12 +69,8 @@ func (c *MetadataClient) FetchMetadata(ctx context.Context, magnetURI string) (*
 		return nil, fmt.Errorf("failed to parse magnet URI: %w", err)
 	}
 	cacheKey := fmt.Sprintf("metadata:%s", m.InfoHash)
-	cachedData, err := c.c.Get(ctx, cacheKey)
-	if err == nil && cachedData != nil {
-		var cachedMetadata MetadataResponse
-		if err := json.Unmarshal(cachedData, &cachedMetadata); err == nil {
-			return &cachedMetadata, nil
-		}
+	if cachedMetadata := c.GetCachedMetadata(ctx, m.InfoHash.String()); cachedMetadata != nil {
+		return cachedMetadata, nil
 	}
 
 	reqBody := MetadataRequest{MagnetURI: magnetURI}
@@ -112,4 +108,19 @@ func (c *MetadataClient) FetchMetadata(ctx context.Context, magnetURI string) (*
 	}
 
 	return &metadata, nil
+}
+
+func (c *MetadataClient) GetCachedMetadata(ctx context.Context, infoHash string) *MetadataResponse {
+	if !c.IsEnabled() {
+		return nil
+	}
+	cacheKey := fmt.Sprintf("metadata:%s", infoHash)
+	cachedData, err := c.c.Get(ctx, cacheKey)
+	if err == nil && cachedData != nil {
+		var cachedMetadata MetadataResponse
+		if err := json.Unmarshal(cachedData, &cachedMetadata); err == nil {
+			return &cachedMetadata
+		}
+	}
+	return nil
 }

--- a/main.go
+++ b/main.go
@@ -25,6 +25,40 @@ func main() {
 
 	redis := cache.NewRedis()
 	searchIndex := meilisearch.NewSearchIndexer(os.Getenv("MEILISEARCH_ADDRESS"), os.Getenv("MEILISEARCH_KEY"), "torrents")
+	
+	// Configure searchable attributes asynchronously
+	go func() {
+		for i := 0; i < 10; i++ {
+			if searchIndex.IsHealthy() {
+				err := searchIndex.UpdateSearchableAttributes([]string{"imdb", "title", "original_title", "context", "files.path"})
+				if err != nil {
+					logging.Error().Err(err).Msg("Failed to update searchable attributes in Meilisearch")
+				} else {
+					logging.Info().Msg("Successfully updated searchable attributes in Meilisearch")
+				}
+
+				err = searchIndex.UpdateSynonyms(map[string][]string{
+					"the": {"o", "a", "os", "as"},
+					"o":   {"the"},
+					"a":   {"the"},
+					"os":  {"the"},
+					"as":  {"the"},
+					"do":  {"of", "from"},
+					"da":  {"of", "from"},
+					"de":  {"of"},
+					"of":  {"do", "da", "de"},
+				})
+				if err != nil {
+					logging.Error().Err(err).Msg("Failed to update synonyms in Meilisearch")
+				} else {
+					logging.Info().Msg("Successfully updated synonyms in Meilisearch")
+				}
+				break
+			}
+			time.Sleep(5 * time.Second)
+		}
+	}()
+
 	var magnetMetadataAPI *magnet.MetadataClient
 	if os.Getenv("MAGNET_METADATA_API_ENABLED") == "true" {
 		timeout := 10 * time.Second
@@ -86,14 +120,15 @@ func main() {
 	indexerMux := http.NewServeMux()
 	metricsMux := http.NewServeMux()
 
-	indexerMux.HandleFunc("/", handler.HandlerIndex)
-	indexerMux.HandleFunc("/indexers/bludv", indexers.HandlerBluDVIndexer)
-	indexerMux.HandleFunc("/indexers/comando_torrents", indexers.HandlerComandoIndexer)
-	indexerMux.HandleFunc("/indexers/rede_torrent", indexers.HandlerRedeTorrentIndexer)
-	indexerMux.HandleFunc("/indexers/starck-filmes", indexers.HandlerStarckFilmesIndexer)
-	indexerMux.HandleFunc("/indexers/torrent-dos-filmes", indexers.HandlerTorrentDosFilmesIndexer)
-	indexerMux.HandleFunc("/indexers/vaca_torrent", indexers.HandlerVacaTorrentIndexer)
-	indexerMux.HandleFunc("/indexers/manual", indexers.HandlerManualIndexer)
+	indexerMux.HandleFunc("/", indexers.HandlerIndex)
+	indexerMux.HandleFunc("/indexers/all", handler.WithMultiQuery(indexers.HandlerMultiIndexers))
+	indexerMux.HandleFunc("/indexers/search", handler.WithMultiQuery(indexers.HandlerMultiIndexers))
+	indexerMux.HandleFunc("/indexers/manual", handler.WithMultiQuery(indexers.HandlerManualIndexer))
+
+	// Register all configured indexers dynamically
+	for name, h := range indexers.GetAllHandlersMap() {
+		indexerMux.HandleFunc("/indexers/"+name, handler.WithMultiQuery(h))
+	}
 	indexerMux.HandleFunc("/search", search.SearchTorrentHandler)
 	indexerMux.HandleFunc("/search/health", search.HealthHandler)
 	indexerMux.HandleFunc("/search/stats", search.StatsHandler)

--- a/main.go
+++ b/main.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 	"os"
 	"strconv"
+	"strings"
 	"time"
 
 	handler "github.com/felipemarinho97/torrent-indexer/api"
@@ -110,8 +111,16 @@ func main() {
 		logging.Error().Err(err).Msg("Failed to parse long-lived cache expiration")
 	}
 
+	disabledIndexers := make(map[string]bool)
+	if disabledEnv := os.Getenv("TORRENT_INDEXER_DISABLED_INDEXERS"); disabledEnv != "" {
+		for _, name := range strings.Split(disabledEnv, ",") {
+			disabledIndexers[strings.TrimSpace(name)] = true
+		}
+	}
+
 	icfg := handler.IndexersConfig{
 		FallbackTitleEnabled: os.Getenv("FALLBACK_TITLE_ENABLED") == "true",
+		DisabledIndexers:     disabledIndexers,
 	}
 
 	indexers := handler.NewIndexers(icfg, redis, metrics, req, searchIndex, magnetMetadataAPI)

--- a/schema/indexed_torrent.go
+++ b/schema/indexed_torrent.go
@@ -5,15 +5,23 @@ import "time"
 type IndexedTorrent struct {
 	Title         string    `json:"title"`
 	OriginalTitle string    `json:"original_title"`
+	Context       string    `json:"context,omitempty"`
 	Details       string    `json:"details"`
-	Year          string    `json:"year"`
-	IMDB          string    `json:"imdb"`
+	Year          string    `json:"year,omitempty"`
+	IMDB          string    `json:"imdb,omitempty"`
 	Audio         []Audio   `json:"audio"`
 	MagnetLink    string    `json:"magnet_link"`
 	Date          time.Time `json:"date"`
 	InfoHash      string    `json:"info_hash"`
-	Trackers      []string  `json:"trackers"`
-	Size          string    `json:"size"`
+	Trackers      []string  `json:"trackers,omitempty"`
+	Size          string    `json:"size,omitempty"`
+	Quality       string    `json:"quality,omitempty"`
+	VideoQuality  string    `json:"video_quality,omitempty"`
+	AudioQuality  string    `json:"audio_quality,omitempty"`
+	Genres        []string  `json:"genres,omitempty"`
+	Subtitles     []string  `json:"subtitles,omitempty"`
+	Duration      string    `json:"duration,omitempty"`
+	Classification string   `json:"classification,omitempty"`
 	Files         []File    `json:"files,omitempty"`
 	LeechCount    int       `json:"leech_count"`
 	SeedCount     int       `json:"seed_count"`

--- a/search/meilisearch.go
+++ b/search/meilisearch.go
@@ -163,132 +163,6 @@ func (t *SearchIndexer) SearchTorrent(query string, limit int) ([]schema.Indexed
 	return result.Hits, nil
 }
 
-// MultiSearchTorrent searches indexed torrents using multiple queries at once.
-func (t *SearchIndexer) MultiSearchTorrent(queries []string, limit int) ([][]schema.IndexedTorrent, error) {
-	url := fmt.Sprintf("%s/multi-search", t.BaseURL)
-	if limit > 100 {
-		limit = 100
-	}
-    
-	var requests []map[string]interface{}
-	for _, q := range queries {
-		requests = append(requests, map[string]interface{}{
-			"indexUid": t.IndexName,
-			"q":        q,
-			"limit":    limit,
-		})
-	}
-
-	requestBody := map[string]interface{}{
-		"queries": requests,
-	}
-
-	jsonData, err := json.Marshal(requestBody)
-	if err != nil {
-		return nil, fmt.Errorf("failed to marshal multi-search query: %w", err)
-	}
-
-	req, err := http.NewRequest("POST", url, bytes.NewBuffer(jsonData))
-	if err != nil {
-		return nil, fmt.Errorf("failed to create request: %w", err)
-	}
-	req.Header.Set("Content-Type", "application/json")
-	if t.APIKey != "" {
-		req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", t.APIKey))
-	}
-
-	resp, err := t.Client.Do(req)
-	if err != nil {
-		return nil, fmt.Errorf("failed to execute request: %w", err)
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(resp.Body)
-		return nil, fmt.Errorf("multi-search failed: %s", body)
-	}
-
-	var result struct {
-		Results []struct {
-			Hits []schema.IndexedTorrent `json:"hits"`
-		} `json:"results"`
-	}
-	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
-		return nil, fmt.Errorf("failed to parse multi-search response: %w", err)
-	}
-
-	var allHits [][]schema.IndexedTorrent
-	for _, res := range result.Results {
-		allHits = append(allHits, res.Hits)
-	}
-
-	return allHits, nil
-}
-
-// UpdateSearchableAttributes sets the searchable attributes for the index.
-func (t *SearchIndexer) UpdateSearchableAttributes(attributes []string) error {
-	url := fmt.Sprintf("%s/indexes/%s/settings/searchable-attributes", t.BaseURL, t.IndexName)
-
-	jsonData, err := json.Marshal(attributes)
-	if err != nil {
-		return fmt.Errorf("failed to marshal attributes: %w", err)
-	}
-
-	req, err := http.NewRequest("PUT", url, bytes.NewBuffer(jsonData))
-	if err != nil {
-		return fmt.Errorf("failed to create request: %w", err)
-	}
-	req.Header.Set("Content-Type", "application/json")
-	if t.APIKey != "" {
-		req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", t.APIKey))
-	}
-
-	resp, err := t.Client.Do(req)
-	if err != nil {
-		return fmt.Errorf("failed to execute request: %w", err)
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusAccepted && resp.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(resp.Body)
-		return fmt.Errorf("failed to update searchable attributes: %s", body)
-	}
-
-	return nil
-}
-
-// UpdateSynonyms sets the synonyms for the index.
-func (t *SearchIndexer) UpdateSynonyms(synonyms map[string][]string) error {
-	url := fmt.Sprintf("%s/indexes/%s/settings/synonyms", t.BaseURL, t.IndexName)
-
-	jsonData, err := json.Marshal(synonyms)
-	if err != nil {
-		return fmt.Errorf("failed to marshal synonyms: %w", err)
-	}
-
-	req, err := http.NewRequest("PUT", url, bytes.NewBuffer(jsonData))
-	if err != nil {
-		return fmt.Errorf("failed to create request: %w", err)
-	}
-	req.Header.Set("Content-Type", "application/json")
-	if t.APIKey != "" {
-		req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", t.APIKey))
-	}
-
-	resp, err := t.Client.Do(req)
-	if err != nil {
-		return fmt.Errorf("failed to execute request: %w", err)
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusAccepted && resp.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(resp.Body)
-		return fmt.Errorf("failed to update synonyms: %s", body)
-	}
-
-	return nil
-}
-
 // GetStats retrieves statistics about the Meilisearch index including document count.
 // This method can be used for health checks and monitoring.
 func (t *SearchIndexer) GetStats() (*IndexStats, error) {
@@ -351,4 +225,66 @@ func (t *SearchIndexer) GetDocumentCount() (int64, error) {
 		return 0, err
 	}
 	return stats.NumberOfDocuments, nil
+}
+
+// UpdateSearchableAttributes configures which fields Meilisearch uses for full-text search.
+func (t *SearchIndexer) UpdateSearchableAttributes(attributes []string) error {
+	url := fmt.Sprintf("%s/indexes/%s/settings/searchable-attributes", t.BaseURL, t.IndexName)
+
+	jsonData, err := json.Marshal(attributes)
+	if err != nil {
+		return fmt.Errorf("failed to marshal searchable attributes: %w", err)
+	}
+
+	req, err := http.NewRequest("PUT", url, bytes.NewBuffer(jsonData))
+	if err != nil {
+		return fmt.Errorf("failed to create request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	if t.APIKey != "" {
+		req.Header.Set("Authorization", "Bearer "+t.APIKey)
+	}
+
+	client := &http.Client{Timeout: 10 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("failed to execute request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 400 {
+		return fmt.Errorf("meilisearch returned status %d", resp.StatusCode)
+	}
+	return nil
+}
+
+// UpdateSynonyms configures synonym mappings in Meilisearch for better search results.
+func (t *SearchIndexer) UpdateSynonyms(synonyms map[string][]string) error {
+	url := fmt.Sprintf("%s/indexes/%s/settings/synonyms", t.BaseURL, t.IndexName)
+
+	jsonData, err := json.Marshal(synonyms)
+	if err != nil {
+		return fmt.Errorf("failed to marshal synonyms: %w", err)
+	}
+
+	req, err := http.NewRequest("PUT", url, bytes.NewBuffer(jsonData))
+	if err != nil {
+		return fmt.Errorf("failed to create request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	if t.APIKey != "" {
+		req.Header.Set("Authorization", "Bearer "+t.APIKey)
+	}
+
+	client := &http.Client{Timeout: 10 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("failed to execute request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 400 {
+		return fmt.Errorf("meilisearch returned status %d", resp.StatusCode)
+	}
+	return nil
 }

--- a/search/meilisearch.go
+++ b/search/meilisearch.go
@@ -163,6 +163,132 @@ func (t *SearchIndexer) SearchTorrent(query string, limit int) ([]schema.Indexed
 	return result.Hits, nil
 }
 
+// MultiSearchTorrent searches indexed torrents using multiple queries at once.
+func (t *SearchIndexer) MultiSearchTorrent(queries []string, limit int) ([][]schema.IndexedTorrent, error) {
+	url := fmt.Sprintf("%s/multi-search", t.BaseURL)
+	if limit > 100 {
+		limit = 100
+	}
+    
+	var requests []map[string]interface{}
+	for _, q := range queries {
+		requests = append(requests, map[string]interface{}{
+			"indexUid": t.IndexName,
+			"q":        q,
+			"limit":    limit,
+		})
+	}
+
+	requestBody := map[string]interface{}{
+		"queries": requests,
+	}
+
+	jsonData, err := json.Marshal(requestBody)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal multi-search query: %w", err)
+	}
+
+	req, err := http.NewRequest("POST", url, bytes.NewBuffer(jsonData))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	if t.APIKey != "" {
+		req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", t.APIKey))
+	}
+
+	resp, err := t.Client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to execute request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("multi-search failed: %s", body)
+	}
+
+	var result struct {
+		Results []struct {
+			Hits []schema.IndexedTorrent `json:"hits"`
+		} `json:"results"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil, fmt.Errorf("failed to parse multi-search response: %w", err)
+	}
+
+	var allHits [][]schema.IndexedTorrent
+	for _, res := range result.Results {
+		allHits = append(allHits, res.Hits)
+	}
+
+	return allHits, nil
+}
+
+// UpdateSearchableAttributes sets the searchable attributes for the index.
+func (t *SearchIndexer) UpdateSearchableAttributes(attributes []string) error {
+	url := fmt.Sprintf("%s/indexes/%s/settings/searchable-attributes", t.BaseURL, t.IndexName)
+
+	jsonData, err := json.Marshal(attributes)
+	if err != nil {
+		return fmt.Errorf("failed to marshal attributes: %w", err)
+	}
+
+	req, err := http.NewRequest("PUT", url, bytes.NewBuffer(jsonData))
+	if err != nil {
+		return fmt.Errorf("failed to create request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	if t.APIKey != "" {
+		req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", t.APIKey))
+	}
+
+	resp, err := t.Client.Do(req)
+	if err != nil {
+		return fmt.Errorf("failed to execute request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusAccepted && resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("failed to update searchable attributes: %s", body)
+	}
+
+	return nil
+}
+
+// UpdateSynonyms sets the synonyms for the index.
+func (t *SearchIndexer) UpdateSynonyms(synonyms map[string][]string) error {
+	url := fmt.Sprintf("%s/indexes/%s/settings/synonyms", t.BaseURL, t.IndexName)
+
+	jsonData, err := json.Marshal(synonyms)
+	if err != nil {
+		return fmt.Errorf("failed to marshal synonyms: %w", err)
+	}
+
+	req, err := http.NewRequest("PUT", url, bytes.NewBuffer(jsonData))
+	if err != nil {
+		return fmt.Errorf("failed to create request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	if t.APIKey != "" {
+		req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", t.APIKey))
+	}
+
+	resp, err := t.Client.Do(req)
+	if err != nil {
+		return fmt.Errorf("failed to execute request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusAccepted && resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("failed to update synonyms: %s", body)
+	}
+
+	return nil
+}
+
 // GetStats retrieves statistics about the Meilisearch index including document count.
 // This method can be used for health checks and monitoring.
 func (t *SearchIndexer) GetStats() (*IndexStats, error) {


### PR DESCRIPTION
# Pull Request: Modernização de Arquitetura, Busca Paralela e Melhorias no MeiliSearch

**Título:** feat: Handlers dinâmicos, unificação de busca, metadados estendidos e otimizações do MeiliSearch

## Descrição
Este PR traz uma série de melhorias arquiteturais e correções no motor do torrent-indexer. O foco principal é tornar o projeto mais independente de configurações manuais (hardcoded), melhorar o tempo de resposta em consultas múltiplas, e otimizar o uso de disco do banco de dados, mantendo 100% de compatibilidade reversa com clientes existentes (Jackett, Addons, etc).

Além das mudanças de infraestrutura, este PR também integra o bugfix do *bludv* discutido na comunidade e corrige a descoberta de metadados via UDP.

---

### Mudanças e Justificativas

#### 1. Registro Dinâmico de Indexadores
**O que foi feito?** 
A lista de indexadores no endpoint raiz (`/`) e o mapeamento de rotas (`/indexers/bludv`, etc.) no `main.go` agora são gerados dinamicamente a partir de um mapa (`GetAllHandlersMap`).
**Por que isso é necessário?** 
Antes, cada vez que um novo site (arquivo `.go`) era adicionado, era preciso modificar manualmente o `main.go` e a documentação na raiz. Agora a arquitetura é "plug-and-play": adicionou o arquivo, a rota sobe e a documentação atualiza sozinha.

#### 2. Unificação da Rota de Busca (`/search`)
**O que foi feito?** 
A rota separada `POST /search/multi` foi removida. O endpoint `GET /search` foi atualizado para suportar múltiplas buscas simultâneas tanto via `GET ?q=a&q=b` quanto via payload `POST {"queries": ["a", "b"]}`.
**Por que isso é necessário?** 
A existência de duas rotas separadas gerava fragmentação na hora de integrar o MeiliSearch em clientes externos. Com a unificação, o comportamento do `/search` se equipara ao `/indexers/all`, devolvendo um Array unificado de resultados de forma padronizada.

#### 3. Paralelismo com WaitGroups (`/indexers/all`)
**O que foi feito?** 
A lógica que consulta múltiplos indexadores ao mesmo tempo (`HandlerMultiIndexers`) foi refatorada para utilizar goroutines com `sync.WaitGroup`. O endpoint também passou a tolerar falhas (se um site cair, ele retorna 200 OK com os resultados dos sites que funcionaram).
**Por que isso é necessário?** 
Se o usuário consulta 5 indexadores e um deles sofre um "timeout" ou erro 500, a requisição inteira falhava. Além disso, a execução paralela reduz o tempo total de resposta de `(Tempo A + Tempo B + Tempo C)` para apenas o tempo do site mais lento da fila.

#### 4. Otimização de Relevância e Armazenamento (MeiliSearch)
**O que foi feito?** 
Adicionada a diretiva `omitempty` em campos opcionais (como `imdb`, `size`, `quality`) no `schema.IndexedTorrent`. Também foi criado um mapeamento automático de Sinônimos no startup (`the` = `o`, `of` = `do`) e inserido a rota `/search/stats` na documentação raiz.
**Por que isso é necessário?** 
O MeiliSearch estava salvando strings vazias (`""`), o que inflava o uso de disco/RAM e quebrava as estatísticas do painel (ex: acusava milhares de torrents com imdb, sendo que estavam vazios). Já o mapeamento de sinônimos impede que o motor ignore artigos como stop-words, consertando buscas de títulos curtos como "The 100" ou "The Batman", que agora são correspondidos corretamente independente da linguagem do crawler.

#### 5. Contexto Inteligente e Parser de Títulos 
**O que foi feito?** 
Foi criada a extração nativa do atributo `Context`. O scraper agora varre o HTML em torno do magnet link e extrai textos valiosos (como temporada, episódio, qualidade, e legendas) que costumam ficar grudados aos botões de download. Além disso, foi incluído um novo Post Processor (`ParseTitleMetadata`) que intercepta o título do post e via RegEx extrai qualidades nativas como `1080p`, `WEB-DL` ou `4K` caso o site não forneça essa tag de forma clara.
**Por que isso é necessário?** 
O campo `Context` se torna uma mina de ouro de meta-dados ultraleves, garantindo que o usuário da API identifique de imediato se aquele Magnet pertence ao Episódio 01 ou 02, o que antigamente exigia regras complicadas para descobrir.

#### 6. Extração Estendida (Opcional via ENV)
**O que foi feito?** 
Agora os scrapers conseguem puxar dados profundos (como Resolução, Qualidade de Áudio/Vídeo, Gêneros, Duração e os Arquivos vindos do Magnet).
**Por que isso é necessário?** 
Isso permite que UIs ricas consumam dados completos sem depender estritamente de APIs de terceiros. **Porém, para proteger usuários de consumo excessivo de disco (Redis/MeiliSearch)**, isso foi desativado por padrão. Caso a pessoa não coloque `ENABLE_EXTENDED_METADATA=true` no `.env`, um processador passará a foice e limpará esses dados extras (mas mantendo o campo ultraleve `Context`), garantindo que o Torrent-Indexer original continue consumindo o mínimo de espaço possível.

#### 7. Bugfixes da Comunidade
**O que foi feito?** 
- Incorporada a correção no parser do `bludv` reportada pelo membro `.bazante`.
- Corrigida a porta `42069/udp` no `docker-compose.yml` para a imagem do `magnet-metadata-api`.
**Por que isso é necessário?** 
O tracker de DHT necessita do protocolo UDP para descobrir peers corretamente e recuperar os arquivos dos metadados. A falta dessa porta causava falhas silenciosas na resolução de magnet links.

---
### Testes Realizados
- Compatibilidade reversa mantida intacta com chamadas do Jackett.
- Indexadores originais não apresentam quebra de estrutura HTML.
- Verificado o comportamento do `omitempty` diretamente na engine local do MeiliSearch.
