### PR TITLE
refactor: adware link resolution into reusable AdwareResolver

### DIFF
--- a/api/bludv.go
+++ b/api/bludv.go
@@ -125,41 +125,24 @@ func getTorrentsBluDV(ctx context.Context, i *Indexer, link, referer string) ([]
 		magnetLinks = append(magnetLinks, magnetLink)
 	})
 
-	adwareDomains := []string{
-		"https://www.seuvideo.xyz",
-		"https://www.systemads.org",
-		"https://superadsgo.xyz",
-	}
+	adwareLinks := i.adwareResolver.ExtractAdwareLinks(textContent)
+	for _, domain := range adwareLinks {
+		magnetLinkDecoded, err := i.adwareResolver.ResolveAdware(ctx, domain)
+		if err != nil {
+			logging.Warn().Err(err).Str("href", domain).Msg("Failed to resolve adware link")
+			continue
+		}
 
-	// Process adware links for each domain in the list
-	for _, domain := range adwareDomains {
-		adwareLinks := textContent.Find(fmt.Sprintf("a[href^=\"%s\"]", domain))
-		adwareLinks.Each(func(_ int, s *goquery.Selection) {
-			href, _ := s.Attr("href")
-			// extract querysting "id" from url
-			parsedUrl, err := url.Parse(href)
-			if err != nil {
-				logging.Error().Err(err).Str("href", href).Msg("Failed to parse URL")
-				return
-			}
-			magnetLink := parsedUrl.Query().Get("id")
-			magnetLinkDecoded, err := utils.DecodeAdLink(magnetLink)
-			if err != nil {
-				logging.Error().Err(err).Str("href", href).Msg("Failed to decode ad link")
-				return
-			}
-
-			// if decoded magnet link is indeed a magnet link, append it
-			if strings.HasPrefix(magnetLinkDecoded, "magnet:") {
-				magnetLinks = append(magnetLinks, magnetLinkDecoded)
-			} else if !strings.Contains(magnetLinkDecoded, "watch.brplayer") {
-				logging.Warn().
-					Str("href", href).
-					Str("decoded", magnetLinkDecoded).
-					Str("indexer", bludv.Label).
-					Msg("Link decoding resulted in non-magnet link")
-			}
-		})
+		// if decoded magnet link is indeed a magnet link, append it
+		if strings.HasPrefix(magnetLinkDecoded, "magnet:") {
+			magnetLinks = append(magnetLinks, magnetLinkDecoded)
+		} else if !strings.Contains(magnetLinkDecoded, "watch.brplayer") {
+			logging.Warn().
+				Str("href", domain).
+				Str("decoded", magnetLinkDecoded).
+				Str("indexer", bludv.Label).
+				Msg("Link decoding resulted in non-magnet link")
+		}
 	}
 
 	var audio []schema.Audio

--- a/api/comando_torrents.go
+++ b/api/comando_torrents.go
@@ -150,6 +150,26 @@ func getTorrents(ctx context.Context, i *Indexer, link, referer string) ([]schem
 		magnetLinks = append(magnetLinks, magnetLink)
 	})
 
+	adwareLinks := i.adwareResolver.ExtractAdwareLinks(textContent)
+	for _, domain := range adwareLinks {
+		magnetLinkDecoded, err := i.adwareResolver.ResolveAdware(ctx, domain)
+		if err != nil {
+			logging.Warn().Err(err).Str("href", domain).Msg("Failed to resolve adware link")
+			continue
+		}
+
+		// if decoded magnet link is indeed a magnet link, append it
+		if strings.HasPrefix(magnetLinkDecoded, "magnet:") {
+			magnetLinks = append(magnetLinks, magnetLinkDecoded)
+		} else if !strings.Contains(magnetLinkDecoded, "watch.brplayer") {
+			logging.Warn().
+				Str("href", domain).
+				Str("decoded", magnetLinkDecoded).
+				Str("indexer", bludv.Label).
+				Msg("Link decoding resulted in non-magnet link")
+		}
+	}
+
 	var audio []schema.Audio
 	var year string
 	var size []string

--- a/api/index.go
+++ b/api/index.go
@@ -12,6 +12,7 @@ import (
 	"github.com/felipemarinho97/torrent-indexer/requester"
 	"github.com/felipemarinho97/torrent-indexer/schema"
 	meilisearch "github.com/felipemarinho97/torrent-indexer/search"
+	"github.com/felipemarinho97/torrent-indexer/utils"
 )
 
 type Indexer struct {
@@ -21,6 +22,7 @@ type Indexer struct {
 	requester         *requester.Requster
 	search            *meilisearch.SearchIndexer
 	magnetMetadataAPI *magnet.MetadataClient
+	adwareResolver    *utils.AdwareResolver
 	postProcessors    []PostProcessorFunc
 }
 
@@ -62,6 +64,7 @@ func NewIndexers(
 	req *requester.Requster,
 	si *meilisearch.SearchIndexer,
 	mc *magnet.MetadataClient,
+	adwareResolver *utils.AdwareResolver,
 ) *Indexer {
 	return &Indexer{
 		config:            config,
@@ -70,6 +73,7 @@ func NewIndexers(
 		requester:         req,
 		search:            si,
 		magnetMetadataAPI: mc,
+		adwareResolver:    adwareResolver,
 		postProcessors:    GlobalPostProcessors,
 	}
 }

--- a/api/starck_filmes.go
+++ b/api/starck_filmes.go
@@ -20,7 +20,7 @@ import (
 
 var starck_filmes = IndexerMeta{
 	Label:       "starck_filmes",
-	URL:         utils.GetIndexerURLFromEnv("INDEXER_STARCK_FILMES_URL", "https://www.starckfilmes-v10.com/"),
+	URL:         utils.GetIndexerURLFromEnv("INDEXER_STARCK_FILMES_URL", "https://www.starck-oficial.com/"),
 	SearchURL:   "?s=",
 	PagePattern: "page/%s",
 }

--- a/api/torrent_dos_filmes.go
+++ b/api/torrent_dos_filmes.go
@@ -20,7 +20,7 @@ import (
 
 var torrent_dos_filmes = IndexerMeta{
 	Label:       "torrent_dos_filmes",
-	URL:         utils.GetIndexerURLFromEnv("INDEXER_TORRENT_DOS_FILMES_URL", "https://torrentdosfilmes.se/"),
+	URL:         utils.GetIndexerURLFromEnv("INDEXER_TORRENT_DOS_FILMES_URL", "https://torrentdosfilmes-v2.xyz/"),
 	SearchURL:   "?s=",
 	PagePattern: "category/dublado/page/%s",
 }
@@ -123,6 +123,26 @@ func getTorrentsTorrentDosFilmes(ctx context.Context, i *Indexer, link, referer 
 		magnetLink, _ := s.Attr("href")
 		magnetLinks = append(magnetLinks, magnetLink)
 	})
+
+	adwareLinks := i.adwareResolver.ExtractAdwareLinks(textContent)
+	for _, domain := range adwareLinks {
+		magnetLinkDecoded, err := i.adwareResolver.ResolveAdware(ctx, domain)
+		if err != nil {
+			logging.Warn().Err(err).Str("href", domain).Msg("Failed to resolve adware link")
+			continue
+		}
+
+		// if decoded magnet link is indeed a magnet link, append it
+		if strings.HasPrefix(magnetLinkDecoded, "magnet:") {
+			magnetLinks = append(magnetLinks, magnetLinkDecoded)
+		} else if !strings.Contains(magnetLinkDecoded, "watch.brplayer") {
+			logging.Warn().
+				Str("href", domain).
+				Str("decoded", magnetLinkDecoded).
+				Str("indexer", bludv.Label).
+				Msg("Link decoding resulted in non-magnet link")
+		}
+	}
 
 	var audio []schema.Audio
 	var year string

--- a/api/vaca_torrent.go
+++ b/api/vaca_torrent.go
@@ -25,7 +25,7 @@ import (
 
 var vacaTorrent = IndexerMeta{
 	Label:       "vaca_torrent",
-	URL:         utils.GetIndexerURLFromEnv("INDEXER_VACA_TORRENT_URL", "https://vacatorrentmov.com/"),
+	URL:         utils.GetIndexerURLFromEnv("INDEXER_VACA_TORRENT_URL", "https://vaqueirofilmes.com/"),
 	SearchURL:   "wp-admin/admin-ajax.php",
 	PagePattern: "page/%s",
 }

--- a/main.go
+++ b/main.go
@@ -14,6 +14,7 @@ import (
 	"github.com/felipemarinho97/torrent-indexer/public"
 	"github.com/felipemarinho97/torrent-indexer/requester"
 	meilisearch "github.com/felipemarinho97/torrent-indexer/search"
+	"github.com/felipemarinho97/torrent-indexer/utils"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 
 	str2duration "github.com/xhit/go-str2duration/v2"
@@ -80,7 +81,10 @@ func main() {
 		FallbackTitleEnabled: os.Getenv("FALLBACK_TITLE_ENABLED") == "true",
 	}
 
-	indexers := handler.NewIndexers(icfg, redis, metrics, req, searchIndex, magnetMetadataAPI)
+	domainsFromEnv := utils.GetEnvOrDefault("ADWARE_DOMAINS", "https://www.seuvideo.xyz,https://www.systemads.org,https://superadsgo.xyz,https://systemads1.com,https://systemads.net")
+	adwareResolver := utils.NewAdwareResolver(redis, domainsFromEnv)
+
+	indexers := handler.NewIndexers(icfg, redis, metrics, req, searchIndex, magnetMetadataAPI, adwareResolver)
 	search := handler.NewMeilisearchHandler(searchIndex)
 
 	indexerMux := http.NewServeMux()

--- a/utils/adware.go
+++ b/utils/adware.go
@@ -1,0 +1,184 @@
+package utils
+
+import (
+	"context"
+	"encoding/base64"
+	"fmt"
+	"html"
+	"io"
+	"net/http"
+	"net/url"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/PuerkitoBio/goquery"
+	"github.com/felipemarinho97/torrent-indexer/logging"
+)
+
+// magnetRegex matches a magnet URI up to the first quote, backslash, whitespace
+// or angle bracket, so it can be pulled out of markup or from a JS string literal.
+var magnetRegex = regexp.MustCompile(`(?i)magnet:\?xt=urn:btih:[^"'\\[:space:]<>]+`)
+
+// AdwareCache is the slice of the cache used by the resolver, kept as an
+// interface so it can be faked in tests. *cache.Redis satisfies it.
+type AdwareCache interface {
+	Get(ctx context.Context, key string) ([]byte, error)
+	SetWithExpiration(ctx context.Context, key string, value []byte, expiration time.Duration) error
+}
+
+type AdwareResolver struct {
+	client        *http.Client
+	cache         AdwareCache
+	adwareDomains []string
+}
+
+func NewAdwareResolver(cache AdwareCache, domains string) *AdwareResolver {
+	client := &http.Client{
+		Timeout: 30 * time.Second,
+		Transport: &http.Transport{
+			MaxIdleConns:        10,
+			MaxIdleConnsPerHost: 5,
+			IdleConnTimeout:     90 * time.Second,
+		},
+	}
+
+	// Trim whitespace from each domain and drop the empty ones, so an empty or
+	// trailing-comma ADWARE_DOMAINS does not turn into an `a[href^=""]` selector
+	// that matches every anchor on the page.
+	var splitDomains []string
+	for domain := range strings.SplitSeq(domains, ",") {
+		if domain = strings.TrimSpace(domain); domain != "" {
+			splitDomains = append(splitDomains, domain)
+		}
+	}
+
+	return &AdwareResolver{
+		client:        client,
+		cache:         cache,
+		adwareDomains: splitDomains,
+	}
+}
+
+func (r *AdwareResolver) ExtractAdwareLinks(pageDom *goquery.Selection) []string {
+	var adwareLinks []string
+
+	for _, domain := range r.adwareDomains {
+		pageDom.Find(fmt.Sprintf("a[href^=\"%s\"]", domain)).Each(func(i int, s *goquery.Selection) {
+			href, exists := s.Attr("href")
+			if exists {
+				adwareLinks = append(adwareLinks, href)
+			}
+		})
+	}
+
+	return adwareLinks
+}
+
+func (r *AdwareResolver) ResolveAdware(ctx context.Context, href string) (string, error) {
+	// extract querysting "id" from url
+	parsedUrl, err := url.Parse(href)
+	if err != nil {
+		logging.Error().Err(err).Str("href", href).Msg("Failed to parse URL")
+		return "", fmt.Errorf("failed to parse URL: %w", err)
+	}
+
+	decodedLink, err := r.ResolveEncodedAdware(ctx, parsedUrl)
+
+	if err == nil {
+		logging.Debug().Str("href", href).Str("decoded", decodedLink).Msg("Successfully resolved encoded adware link")
+		return decodedLink, nil
+	}
+
+	logging.Warn().Str("href", href).Msg("Failed to resolve encoded adware link - trying web resolution")
+
+	magnetLink, err := r.ResolveWebAdware(ctx, href)
+
+	if err != nil {
+		logging.Error().Err(err).Str("href", href).Msg("Failed to resolve adware link")
+		return "", fmt.Errorf("failed to resolve adware link: %w", err)
+	}
+
+	if !IsMagnetLink(magnetLink) {
+		logging.Error().Str("href", href).Str("decoded", magnetLink).Msg("Decoded link is not a valid magnet link")
+		return "", fmt.Errorf("exhausted all resolution methods for adware link %s", href)
+	}
+
+	return magnetLink, nil
+}
+
+// ResolveEncodedAdware decodes the magnet link the adware page carries in its
+// "id" query parameter, which holds the reversed base64 of the (HTML-escaped)
+// magnet link. It performs no I/O, so the adware page never has to be fetched.
+func (r *AdwareResolver) ResolveEncodedAdware(ctx context.Context, adURL *url.URL) (string, error) {
+	encoded := adURL.Query().Get("id")
+	if encoded == "" {
+		return "", fmt.Errorf("empty string")
+	}
+	reversed := reverseString(encoded)
+
+	decodedBytes, err := base64.StdEncoding.DecodeString(reversed)
+	if err != nil {
+		return "", err
+	}
+
+	htmlUnescaped := html.UnescapeString(string(decodedBytes))
+
+	if !IsMagnetLink(htmlUnescaped) {
+		return "", fmt.Errorf("decoded link is not a valid magnet link: %s", htmlUnescaped)
+	}
+
+	return htmlUnescaped, nil
+}
+
+// ResolveWebAdware fetches the adware page and extracts the magnet link from its HTML.
+// It also caches the result for future requests.
+func (r *AdwareResolver) ResolveWebAdware(ctx context.Context, url string) (string, error) {
+	key := fmt.Sprintf("adware:%s", url)
+
+	cachedLink, err := r.cache.Get(ctx, key)
+	if err == nil {
+		logging.Debug().Str("url", url).Msg("Adware link found in cache")
+		return string(cachedLink), nil
+	}
+
+	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
+	if err != nil {
+		return "", fmt.Errorf("failed to create request: %w", err)
+	}
+
+	req.Header.Set("User-Agent", SpoofedUserAgent)
+	req.Header.Set("Accept", "*/*")
+
+	resp, err := r.client.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("failed to fetch adware page: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("unexpected status code: %d", resp.StatusCode)
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", fmt.Errorf("failed to read response body: %w", err)
+	}
+
+	// Step 2: Extract the magnet link from the page source
+	magnetLink := magnetRegex.FindString(string(body))
+	if magnetLink == "" {
+		return "", fmt.Errorf("magnet link not found in adware page")
+	}
+
+	logging.Debug().Str("url", url).Str("magnetLink", magnetLink).Msg("Adware link resolved successfully")
+
+	// Step 3: Cache the resolved link for future requests
+	logging.Debug().Str("url", url).Str("magnetLink", magnetLink).Msg("Caching adware link")
+	err = r.cache.SetWithExpiration(ctx, key, []byte(magnetLink), 24*time.Hour)
+	if err != nil {
+		logging.Warn().Err(err).Str("url", url).Msg("Failed to cache adware link")
+	}
+
+	return magnetLink, nil
+}

--- a/utils/adware_test.go
+++ b/utils/adware_test.go
@@ -1,0 +1,460 @@
+package utils
+
+import (
+	"context"
+	"encoding/base64"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/PuerkitoBio/goquery"
+)
+
+const wantMagnet = "magnet:?xt=urn:btih:e9a96e84e4d763a8fa70bf156f5bd30b61f2fc5c&tr=udp%3A%2F%2Ftracker.example.com%3A80%2Fannounce&tr=udp%3A%2F%2Ftracker.sample.com%3A83%2Fannounce"
+
+var errCacheMiss = errors.New("cache miss")
+
+// fakeCache is an in-memory adwareCache that records what was written to it.
+type fakeCache struct {
+	entries map[string][]byte
+	setTTLs map[string]time.Duration
+	setErr  error
+}
+
+func newFakeCache() *fakeCache {
+	return &fakeCache{
+		entries: map[string][]byte{},
+		setTTLs: map[string]time.Duration{},
+	}
+}
+
+func (f *fakeCache) Get(_ context.Context, key string) ([]byte, error) {
+	value, ok := f.entries[key]
+	if !ok {
+		return nil, errCacheMiss
+	}
+	return value, nil
+}
+
+func (f *fakeCache) SetWithExpiration(_ context.Context, key string, value []byte, expiration time.Duration) error {
+	if f.setErr != nil {
+		return f.setErr
+	}
+	f.entries[key] = value
+	f.setTTLs[key] = expiration
+	return nil
+}
+
+// adwareID builds the value an adware link carries in its "id" query parameter:
+// the reversed base64 of the (HTML-escaped) magnet link.
+func adwareID(link string) string {
+	return reverseString(base64.StdEncoding.EncodeToString([]byte(link)))
+}
+
+// adwareURL builds an adware link on host carrying id in its "id" parameter.
+func adwareURL(t *testing.T, host, id string) *url.URL {
+	t.Helper()
+
+	parsed, err := url.Parse(host + "/go")
+	if err != nil {
+		t.Fatalf("url.Parse(%q) error = %v", host, err)
+	}
+	if id != "" {
+		parsed.RawQuery = url.Values{"id": {id}}.Encode()
+	}
+	return parsed
+}
+
+// newTestResolver serves the given page and returns a resolver pointed at it,
+// along with the page URL and a counter of how many requests it received.
+func newTestResolver(t *testing.T, cache AdwareCache, status int, page string) (*AdwareResolver, string, *int) {
+	t.Helper()
+
+	hits := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hits++
+		if got := r.Header.Get("User-Agent"); got != SpoofedUserAgent {
+			t.Errorf("User-Agent = %q, want %q", got, SpoofedUserAgent)
+		}
+		w.WriteHeader(status)
+		_, _ = w.Write([]byte(page))
+	}))
+	t.Cleanup(server.Close)
+
+	return NewAdwareResolver(cache, server.URL), server.URL, &hits
+}
+
+func TestNewAdwareResolver_Domains(t *testing.T) {
+	tests := []struct {
+		name    string
+		domains string
+		want    []string
+	}{
+		{
+			name:    "single domain",
+			domains: "https://www.seuvideo.xyz",
+			want:    []string{"https://www.seuvideo.xyz"},
+		},
+		{
+			name:    "comma separated domains",
+			domains: "https://www.seuvideo.xyz,https://www.systemads.org,https://superadsgo.xyz",
+			want:    []string{"https://www.seuvideo.xyz", "https://www.systemads.org", "https://superadsgo.xyz"},
+		},
+		{
+			name:    "surrounding whitespace is trimmed",
+			domains: " https://www.seuvideo.xyz ,\thttps://www.systemads.org\n",
+			want:    []string{"https://www.seuvideo.xyz", "https://www.systemads.org"},
+		},
+		{
+			name:    "empty entries are dropped",
+			domains: "https://www.seuvideo.xyz,,  ,https://superadsgo.xyz,",
+			want:    []string{"https://www.seuvideo.xyz", "https://superadsgo.xyz"},
+		},
+		{
+			name:    "empty configuration yields no domains",
+			domains: "",
+			want:    nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resolver := NewAdwareResolver(newFakeCache(), tt.domains)
+			if !reflect.DeepEqual(resolver.adwareDomains, tt.want) {
+				t.Errorf("adwareDomains = %q, want %q", resolver.adwareDomains, tt.want)
+			}
+		})
+	}
+}
+
+func TestAdwareResolver_ExtractAdwareLinks(t *testing.T) {
+	const page = `<div class="entry-content">
+	<a href="magnet:?xt=urn:btih:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa">Magnet</a>
+	<a href="https://www.seuvideo.xyz/go?id=abc">1080p</a>
+	<a href="https://superadsgo.xyz/go?id=def">720p</a>
+	<a href="https://www.seuvideo.xyz.evil.com/go?id=ghi">Impostor</a>
+	<a href="https://legit.example.com/download">Site</a>
+	<a>No href at all</a>
+</div>`
+
+	tests := []struct {
+		name    string
+		domains string
+		want    []string
+	}{
+		{
+			name:    "links are collected per configured domain",
+			domains: "https://www.seuvideo.xyz,https://superadsgo.xyz",
+			want: []string{
+				"https://www.seuvideo.xyz/go?id=abc",
+				"https://www.seuvideo.xyz.evil.com/go?id=ghi",
+				"https://superadsgo.xyz/go?id=def",
+			},
+		},
+		{
+			name:    "domains with no match are skipped",
+			domains: "https://superadsgo.xyz,https://www.systemads.org",
+			want:    []string{"https://superadsgo.xyz/go?id=def"},
+		},
+		{
+			name:    "no configured domains extracts nothing",
+			domains: "",
+			want:    nil,
+		},
+		{
+			name:    "unrelated domain extracts nothing",
+			domains: "https://www.systemads.org",
+			want:    nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			doc, err := goquery.NewDocumentFromReader(strings.NewReader(page))
+			if err != nil {
+				t.Fatalf("failed to parse test page: %v", err)
+			}
+
+			resolver := NewAdwareResolver(newFakeCache(), tt.domains)
+			got := resolver.ExtractAdwareLinks(doc.Selection)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("ExtractAdwareLinks() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestAdwareResolver_ResolveEncodedAdware(t *testing.T) {
+	htmlEscapedMagnet := strings.ReplaceAll(wantMagnet, "&", "&amp;")
+
+	tests := []struct {
+		name string
+		// id is the raw value of the "id" query parameter; when empty the
+		// parameter is left off the URL entirely.
+		id      string
+		want    string
+		wantErr bool
+	}{
+		{
+			name: "reversed base64 magnet link",
+			id:   "jVzYmJjZxYjYwMDZiVjZ2UTMmJGM3EmZ4E2M2cDZ0UGN4UmN5EWOlpDapRnY64mc11Dd49jO0VmbnFWb",
+			want: "magnet:?xt=urn:btih:e9a96e84e4d763a8fa70bf156f5bd30b61f2fc5c",
+		},
+		{
+			name: "magnet link with trackers",
+			id:   adwareID(wantMagnet),
+			want: wantMagnet,
+		},
+		{
+			name: "html entities in the decoded link are unescaped",
+			id:   adwareID(htmlEscapedMagnet),
+			want: wantMagnet,
+		},
+		{
+			name:    "no id query parameter",
+			id:      "",
+			wantErr: true,
+		},
+		{
+			name:    "id is not valid base64",
+			id:      "invalid_encoded_string",
+			wantErr: true,
+		},
+		{
+			name:    "id is base64 but not reversed",
+			id:      base64.StdEncoding.EncodeToString([]byte(wantMagnet)),
+			wantErr: true,
+		},
+		{
+			name:    "decodes to a non-magnet link",
+			id:      adwareID("https://watch.brplayer.example/movie/42"),
+			wantErr: true,
+		},
+		{
+			name:    "decodes to a magnet scheme without a query",
+			id:      adwareID("magnet:"),
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resolver := NewAdwareResolver(newFakeCache(), "https://ads.example.com")
+
+			got, err := resolver.ResolveEncodedAdware(context.Background(), adwareURL(t, "https://ads.example.com", tt.id))
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("ResolveEncodedAdware() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if got != tt.want {
+				t.Errorf("ResolveEncodedAdware() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestAdwareResolver_ResolveAdware(t *testing.T) {
+	tests := []struct {
+		name string // description of this test case
+		// Named input parameters for target function.
+		page    string
+		want    string
+		wantErr bool
+	}{
+		{
+			name: "magnet assigned to a JS const inside a script tag",
+			page: `<script >
+const DEST_URL     = "magnet:?xt=urn:btih:e9a96e84e4d763a8fa70bf156f5bd30b61f2fc5c&tr=udp%3A%2F%2Ftracker.example.com%3A80%2Fannounce&tr=udp%3A%2F%2Ftracker.sample.com%3A83%2Fannounce";
+</script>`,
+			want: wantMagnet,
+		},
+		{
+			name: "magnet inside a full adware page",
+			page: `<!DOCTYPE html>
+<html lang="pt-BR">
+	<head>
+		<title>Aguarde...</title>
+		<script src="https://ads.example.com/loader.js"></script>
+	</head>
+	<body>
+		<div id="countdown">5</div>
+		<script >
+const DEST_URL     = "magnet:?xt=urn:btih:e9a96e84e4d763a8fa70bf156f5bd30b61f2fc5c&tr=udp%3A%2F%2Ftracker.example.com%3A80%2Fannounce&tr=udp%3A%2F%2Ftracker.sample.com%3A83%2Fannounce";
+setTimeout(function () { window.location.href = DEST_URL; }, 5000);
+		</script>
+	</body>
+</html>`,
+			want: wantMagnet,
+		},
+		{
+			name: "minified html with no whitespace around the magnet",
+			page: `<!DOCTYPE html><html><head><title>Aguarde...</title></head><body><div id="countdown">5</div><script>const DEST_URL="magnet:?xt=urn:btih:e9a96e84e4d763a8fa70bf156f5bd30b61f2fc5c&tr=udp%3A%2F%2Ftracker.example.com%3A80%2Fannounce&tr=udp%3A%2F%2Ftracker.sample.com%3A83%2Fannounce";setTimeout(function(){window.location.href=DEST_URL},5000);</script></body></html>`,
+			want: wantMagnet,
+		},
+		{
+			name: "magnet in an anchor href",
+			page: `<a class="btn" href="` + wantMagnet + `">Baixar</a>`,
+			want: wantMagnet,
+		},
+		{
+			name: "first magnet wins when the page has several",
+			page: `<a href="` + wantMagnet + `">1080p</a>` +
+				`<a href="magnet:?xt=urn:btih:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa">720p</a>`,
+			want: wantMagnet,
+		},
+		{
+			name: "no magnet link in the page",
+			page: `<!DOCTYPE html>
+<html>
+	<head><title>Aguarde...</title></head>
+	<body>
+		<div id="countdown">5</div>
+		<script >
+const DEST_URL     = "https://example.com/download?id=42";
+</script>
+	</body>
+</html>`,
+			wantErr: true,
+		},
+		{
+			name:    "minified html with no magnet link",
+			page:    `<!DOCTYPE html><html><head><title>Aguarde...</title></head><body><script>const DEST_URL="https://example.com/download?id=42";window.location.href=DEST_URL;</script></body></html>`,
+			wantErr: true,
+		},
+		{
+			name:    "empty page",
+			page:    "",
+			wantErr: true,
+		},
+		{
+			name:    "magnet scheme without an infohash",
+			page:    `<a href="magnet:?dn=Some.Movie.2024.1080p">Baixar</a>`,
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cache := newFakeCache()
+			resolver, pageURL, hits := newTestResolver(t, cache, http.StatusOK, tt.page)
+
+			got, err := resolver.ResolveAdware(context.Background(), pageURL)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("ResolveAdware() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if got != tt.want {
+				t.Errorf("ResolveAdware() = %v, want %v", got, tt.want)
+			}
+			if *hits != 1 {
+				t.Errorf("adware page requested %d times, want 1", *hits)
+			}
+
+			// A resolved magnet is cached for 24h; a failed one is not cached at all.
+			key := "adware:" + pageURL
+			cached, ok := cache.entries[key]
+			if tt.wantErr {
+				if ok {
+					t.Errorf("cached %q under %q, want nothing cached on failure", cached, key)
+				}
+				return
+			}
+			if !ok {
+				t.Fatalf("nothing cached under %q, want %q", key, tt.want)
+			}
+			if string(cached) != tt.want {
+				t.Errorf("cached = %v, want %v", string(cached), tt.want)
+			}
+			if cache.setTTLs[key] != 24*time.Hour {
+				t.Errorf("cache TTL = %v, want %v", cache.setTTLs[key], 24*time.Hour)
+			}
+		})
+	}
+}
+
+func TestAdwareResolver_ResolveAdwarePrefersTheEncodedLink(t *testing.T) {
+	resolver, pageURL, hits := newTestResolver(t, newFakeCache(), http.StatusOK, "<html><body>no magnet here</body></html>")
+	href := adwareURL(t, pageURL, adwareID(wantMagnet)).String()
+
+	got, err := resolver.ResolveAdware(context.Background(), href)
+	if err != nil {
+		t.Fatalf("ResolveAdware() error = %v, want nil", err)
+	}
+	if got != wantMagnet {
+		t.Errorf("ResolveAdware() = %v, want %v", got, wantMagnet)
+	}
+	if *hits != 0 {
+		t.Errorf("adware page requested %d times, want 0 when the link decodes locally", *hits)
+	}
+}
+
+func TestAdwareResolver_ResolveAdwareFallsBackToTheWebWhenTheIDIsUndecodable(t *testing.T) {
+	resolver, pageURL, hits := newTestResolver(t, newFakeCache(), http.StatusOK, `<a href="`+wantMagnet+`">Baixar</a>`)
+	href := adwareURL(t, pageURL, "not-base64-at-all").String()
+
+	got, err := resolver.ResolveAdware(context.Background(), href)
+	if err != nil {
+		t.Fatalf("ResolveAdware() error = %v, want nil", err)
+	}
+	if got != wantMagnet {
+		t.Errorf("ResolveAdware() = %v, want %v", got, wantMagnet)
+	}
+	if *hits != 1 {
+		t.Errorf("adware page requested %d times, want 1", *hits)
+	}
+}
+
+func TestAdwareResolver_ResolveAdwareServesFromCache(t *testing.T) {
+	cache := newFakeCache()
+	resolver, pageURL, hits := newTestResolver(t, cache, http.StatusOK, "<html><body>no magnet here</body></html>")
+	cache.entries["adware:"+pageURL] = []byte(wantMagnet)
+
+	got, err := resolver.ResolveAdware(context.Background(), pageURL)
+	if err != nil {
+		t.Fatalf("ResolveAdware() error = %v, want nil", err)
+	}
+	if got != wantMagnet {
+		t.Errorf("ResolveAdware() = %v, want %v", got, wantMagnet)
+	}
+	if *hits != 0 {
+		t.Errorf("adware page requested %d times, want 0 on a cache hit", *hits)
+	}
+}
+
+func TestAdwareResolver_ResolveAdwareCacheWriteFailure(t *testing.T) {
+	cache := newFakeCache()
+	cache.setErr = errors.New("redis is down")
+	resolver, pageURL, _ := newTestResolver(t, cache, http.StatusOK, `<a href="`+wantMagnet+`">Baixar</a>`)
+
+	// A cache write failure is logged but must not fail the resolution.
+	got, err := resolver.ResolveAdware(context.Background(), pageURL)
+	if err != nil {
+		t.Fatalf("ResolveAdware() error = %v, want nil", err)
+	}
+	if got != wantMagnet {
+		t.Errorf("ResolveAdware() = %v, want %v", got, wantMagnet)
+	}
+}
+
+func TestAdwareResolver_ResolveAdwareNonOKStatus(t *testing.T) {
+	resolver, pageURL, _ := newTestResolver(t, newFakeCache(), http.StatusNotFound, `<a href="`+wantMagnet+`">Baixar</a>`)
+
+	got, err := resolver.ResolveAdware(context.Background(), pageURL)
+	if err == nil {
+		t.Fatalf("ResolveAdware() error = nil, want an error for a 404 response")
+	}
+	if got != "" {
+		t.Errorf("ResolveAdware() = %v, want empty string", got)
+	}
+}
+
+func TestAdwareResolver_ResolveAdwareUnparseableURL(t *testing.T) {
+	resolver := NewAdwareResolver(newFakeCache(), "https://ads.example.com")
+
+	got, err := resolver.ResolveAdware(context.Background(), "://ads.example.com/go?id=abc")
+	if err == nil {
+		t.Fatalf("ResolveAdware() error = nil, want an error for an unparseable URL")
+	}
+	if got != "" {
+		t.Errorf("ResolveAdware() = %v, want empty string", got)
+	}
+}

--- a/utils/decoder.go
+++ b/utils/decoder.go
@@ -3,24 +3,7 @@ package utils
 import (
 	"encoding/base64"
 	"fmt"
-	"html"
 )
-
-func DecodeAdLink(encodedStr string) (string, error) {
-	if encodedStr == "" {
-		return "", fmt.Errorf("empty string")
-	}
-	reversed := reverseString(encodedStr)
-
-	decodedBytes, err := base64.StdEncoding.DecodeString(reversed)
-	if err != nil {
-		return "", err
-	}
-
-	htmlUnescaped := html.UnescapeString(string(decodedBytes))
-
-	return htmlUnescaped, nil
-}
 
 func Base64Decode(input string) (string, error) {
 	if input == "" {

--- a/utils/decoder_test.go
+++ b/utils/decoder_test.go
@@ -6,52 +6,6 @@ import (
 	"github.com/felipemarinho97/torrent-indexer/utils"
 )
 
-func TestDecodeAdLink(t *testing.T) {
-	tests := []struct {
-		name string // description of this test case
-		// Named input parameters for target function.
-		encodedStr string
-		want       string
-		wantErr    bool
-	}{
-		{
-			name:       "Valid encoded string",
-			encodedStr: "jVzYmJjZxYjYwMDZiVjZ2UTMmJGM3EmZ4E2M2cDZ0UGN4UmN5EWOlpDapRnY64mc11Dd49jO0VmbnFWb",
-			want:       "magnet:?xt=urn:btih:e9a96e84e4d763a8fa70bf156f5bd30b61f2fc5c",
-			wantErr:    false,
-		},
-		{
-			name:       "Invalid encoded string",
-			encodedStr: "invalid_encoded_string",
-			want:       "",
-			wantErr:    true,
-		},
-		{
-			name:       "Empty string",
-			encodedStr: "",
-			want:       "",
-			wantErr:    true,
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got, gotErr := utils.DecodeAdLink(tt.encodedStr)
-			if gotErr != nil {
-				if !tt.wantErr {
-					t.Errorf("DecodeAdLink() failed: %v", gotErr)
-				}
-				return
-			}
-			if tt.wantErr {
-				t.Fatal("DecodeAdLink() succeeded unexpectedly")
-			}
-			if got != tt.want {
-				t.Errorf("DecodeAdLink() = %v, want %v", got, tt.want)
-			}
-		})
-	}
-}
-
 func TestBase64Decode(t *testing.T) {
 	tests := []struct {
 		name string // description of this test case
@@ -138,6 +92,52 @@ func TestDecodeStarckDataU(t *testing.T) {
 			}
 			if got != tt.want {
 				t.Errorf("DecodeStarckDataU() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIsMagnetLink(t *testing.T) {
+	tests := []struct {
+		name string
+		link string
+		want bool
+	}{
+		{
+			name: "magnet link with an infohash",
+			link: "magnet:?xt=urn:btih:e9a96e84e4d763a8fa70bf156f5bd30b61f2fc5c",
+			want: true,
+		},
+		{
+			name: "magnet link with only a display name",
+			link: "magnet:?dn=Some.Movie.2024.1080p",
+			want: true,
+		},
+		{
+			name: "magnet scheme without a query",
+			link: "magnet:",
+			want: false,
+		},
+		{
+			name: "http link",
+			link: "https://watch.brplayer.example/movie/42",
+			want: false,
+		},
+		{
+			name: "magnet not at the start of the string",
+			link: "https://ads.example.com/go?to=magnet:?xt=urn:btih:e9a9",
+			want: false,
+		},
+		{
+			name: "empty string",
+			link: "",
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := utils.IsMagnetLink(tt.link); got != tt.want {
+				t.Errorf("IsMagnetLink(%q) = %v, want %v", tt.link, got, tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
- Extract adware handling logic from BluDV indexer into new utils.AdwareResolver
- Support both encoded parameter decoding and web page scraping for magnet extraction
- Add Redis caching with 24h TTL for resolved adware links
- Make adware domains configurable via ADWARE_DOMAINS environment variable
- Apply resolver to BLUDV, Comando Torrents and Torrent dos Filmes indexers
- Add comprehensive test coverage for resolver behavior
- Update outdated indexers URLs

<img width="1813" height="1971" alt="comando" src="https://github.com/user-attachments/assets/153385ab-36a0-4b95-a194-6fc41c61af24" />
<img width="1813" height="1971" alt="torrentdosfilmes" src="https://github.com/user-attachments/assets/3bb2a694-7999-4b2b-9bf6-a098c85096e0" />
<img width="1813" height="1971" alt="bludv" src="https://github.com/user-attachments/assets/8f86acbb-186b-4507-9978-5414a64ad40e" />


Fixes #82 #83