### PR TITLE
fix: uppercase encoded infohash

### DIFF
--- a/magnet/magnet.go
+++ b/magnet/magnet.go
@@ -57,7 +57,7 @@ func parseInfohash(xt string) (ih T, err error) {
 		err = errors.New("bad xt parameter prefix")
 		return
 	}
-	encoded := xt[len(xtPrefix):]
+	encoded := strings.ToUpper(xt[len(xtPrefix):])
 	decode := func() func(dst, src []byte) (int, error) {
 		switch len(encoded) {
 		case 40:


### PR DESCRIPTION
The Base32 alphabet only includes uppercase characters. Therefore, if an encoded infohash contains lowercase values, it will be rejected outright.

This fixes it by simple uppercasing the infohash before decoding it.