### PR TITLE
fix(bludv): assign per-magnet size on multi-version posts

### DIFF
--- a/api/bludv.go
+++ b/api/bludv.go
@@ -120,9 +120,16 @@ func getTorrentsBluDV(ctx context.Context, i *Indexer, link, referer string) ([]
 	date := getPublishedDate(doc)
 	magnets := textContent.Find("a[href^=\"magnet\"]")
 	var magnetLinks []string
+	// magnetSizes holds the size found right next to each magnet (1:1 with
+	// magnetLinks). BluDV posts with multiple versions list one size per
+	// download button ("SERVIDOR PARA DOWNLOAD ... (X GB)"), so reading it
+	// per-magnet is reliable even when the global "Tamanho:" field lists
+	// several sizes. Empty when none is found (falls back below).
+	var magnetSizes []string
 	magnets.Each(func(i int, s *goquery.Selection) {
 		magnetLink, _ := s.Attr("href")
 		magnetLinks = append(magnetLinks, magnetLink)
+		magnetSizes = append(magnetSizes, findSizeNearMagnet(s))
 	})
 
 	adwareDomains := []string{
@@ -152,6 +159,7 @@ func getTorrentsBluDV(ctx context.Context, i *Indexer, link, referer string) ([]
 			// if decoded magnet link is indeed a magnet link, append it
 			if strings.HasPrefix(magnetLinkDecoded, "magnet:") {
 				magnetLinks = append(magnetLinks, magnetLinkDecoded)
+				magnetSizes = append(magnetSizes, findSizeNearMagnet(s))
 			} else if !strings.Contains(magnetLinkDecoded, "watch.brplayer") {
 				logging.Warn().
 					Str("href", href).
@@ -226,9 +234,15 @@ func getTorrentsBluDV(ctx context.Context, i *Indexer, link, referer string) ([]
 
 			title := processTitle(title, magnetAudio)
 
-			// if the number of sizes is equal to the number of magnets, then assign the size to each indexed torrent in order
+			// Prefer the size found right next to this magnet. This is robust
+			// for multi-version posts where the global "Tamanho:" field carries
+			// several sizes (so the count-based mapping below cannot line up).
 			var mySize string
-			if len(size) == len(magnetLinks) {
+			if it < len(magnetSizes) && magnetSizes[it] != "" {
+				mySize = magnetSizes[it]
+			} else if len(size) == len(magnetLinks) {
+				// fallback: if the number of sizes is equal to the number of
+				// magnets, assign the size to each indexed torrent in order
 				mySize = size[it]
 			}
 			if mySize == "" {

--- a/api/bludv_test.go
+++ b/api/bludv_test.go
@@ -1,0 +1,66 @@
+package handler
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/PuerkitoBio/goquery"
+)
+
+// Test_findSizeNearMagnet reproduces a BluDV multi-version post: several
+// download buttons, each with its own size, followed by the magnet anchor.
+// The global "Tamanho:" field lists every size at once, which used to make the
+// count-based mapping fail and leave every torrent without a size. The
+// per-magnet lookup must return the size sitting right next to each magnet.
+func Test_findSizeNearMagnet(t *testing.T) {
+	html := `<html><body><div class="content">
+		<p><strong>Tamanho:</strong> 1.28 GB | 2.34 GB</p>
+		<p><em>SERVIDOR PARA DOWNLOAD BluRay 720p (1.28 GB)</em></p>
+		<div><a href="magnet:?xt=urn:btih:aaa"><img/></a></div>
+		<p><em>SERVIDOR PARA DOWNLOAD BluRay 1080p (2.34 GB)</em></p>
+		<div><a href="magnet:?xt=urn:btih:bbb"><img/></a></div>
+		<p><em>SERVIDOR PARA DOWNLOAD (sem tamanho aqui)</em></p>
+		<div><a href="magnet:?xt=urn:btih:ccc"><img/></a></div>
+	</div></body></html>`
+
+	doc, err := goquery.NewDocumentFromReader(strings.NewReader(html))
+	if err != nil {
+		t.Fatalf("failed to parse html: %v", err)
+	}
+
+	want := []string{"1.28 GB", "2.34 GB", ""}
+	var got []string
+	doc.Find(`a[href^="magnet"]`).Each(func(_ int, s *goquery.Selection) {
+		got = append(got, findSizeNearMagnet(s))
+	})
+
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("findSizeNearMagnet() = %v, want %v", got, want)
+	}
+}
+
+// Test_findSizeNearMagnet_inlineWithBreak covers the "Vingadores Ultimato"
+// layout, where the size sits in a sibling of the magnet anchor itself (same
+// block, separated by a <br/>) instead of a sibling of a wrapper element.
+func Test_findSizeNearMagnet_inlineWithBreak(t *testing.T) {
+	html := `<html><body><div class="content"><div>` +
+		`<span><em>SERVIDOR PARA DOWNLOAD BluRay 720p (2.72 GB)</em></span><br/><a href="magnet:?xt=urn:btih:aaa">Magnet-Link</a>` +
+		`<span><em>SERVIDOR PARA DOWNLOAD BluRay 1080p (2.33 GB)</em></span><br/><a href="magnet:?xt=urn:btih:bbb">Magnet-Link</a>` +
+		`</div></div></body></html>`
+
+	doc, err := goquery.NewDocumentFromReader(strings.NewReader(html))
+	if err != nil {
+		t.Fatalf("failed to parse html: %v", err)
+	}
+
+	want := []string{"2.72 GB", "2.33 GB"}
+	var got []string
+	doc.Find(`a[href^="magnet"]`).Each(func(_ int, s *goquery.Selection) {
+		got = append(got, findSizeNearMagnet(s))
+	})
+
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("findSizeNearMagnet() inline layout = %v, want %v", got, want)
+	}
+}

--- a/api/common.go
+++ b/api/common.go
@@ -198,6 +198,37 @@ func findSizesFromText(text string) []string {
 	return sizes
 }
 
+// findSizeNearMagnet returns the download size that belongs to a single magnet
+// link. On BluDV each download button is rendered as
+// "SERVIDOR PARA DOWNLOAD BluRay 1080p (2.34 GB)" right before its magnet, but in
+// two layouts: the size can sit in a sibling of the magnet anchor itself
+// (separated by a <br/> inside the same <p>), or in a sibling of the anchor's
+// wrapper element (e.g. the anchor inside a <div>, the size in the previous <p>).
+// We check the anchor's own previous siblings first, then the wrapper's. Reading
+// it per-magnet is reliable even for multi-version posts, where the global
+// "Tamanho:" field lists several sizes at once. Returns "" when none is found.
+func findSizeNearMagnet(magnetAnchor *goquery.Selection) string {
+	if s := sizeFromPrevSiblings(magnetAnchor); s != "" {
+		return s
+	}
+	return sizeFromPrevSiblings(magnetAnchor.Parent())
+}
+
+// sizeFromPrevSiblings walks backwards through the previous siblings of node and
+// returns the closest size, stopping before another magnet link (whose size
+// belongs to it). Returns "" when no size is found.
+func sizeFromPrevSiblings(node *goquery.Selection) string {
+	for sib := node.Prev(); sib.Length() > 0; sib = sib.Prev() {
+		if sib.Is(`a[href^="magnet"]`) || sib.Find(`a[href^="magnet"]`).Length() > 0 {
+			break
+		}
+		if sizes := findSizesFromText(sib.Text()); len(sizes) > 0 {
+			return sizes[len(sizes)-1]
+		}
+	}
+	return ""
+}
+
 var imdbLinkRE = regexp.MustCompile(`https://www.imdb.com(/[a-z]{2})?/title/(tt\d+)/?`)
 var subtitlesHintIMDBLinkRE = regexp.MustCompile(`imdbid-((tt)?\d+)`)
 


### PR DESCRIPTION
## Problem

BluDV posts that offer multiple versions (720p, 1080p, 4K, Open Matte, ...) come back with an **empty size** on every torrent. Single-version posts are fine.

## Root cause

`getTorrentsBluDV` collects sizes from the post's `<p>` elements (including the `Tamanho:` metadata field), dedupes them with `StableUniq`, and only assigns a size to each magnet when the counts match exactly:

```go
if len(size) == len(magnetLinks) {
    mySize = size[it]
}
```

Multi-version posts list several sizes at once in the `Tamanho:` field (e.g. `Tamanho: 1.28 GB | 2.34 GB`), so after dedup the number of sizes almost never equals the number of magnets — and `mySize` stays empty for all of them.

Evidence (same movie, two posts):

| Post | `Tamanho:` field | magnets | result |
|------|------------------|---------|--------|
| `.../os-vingadores-...-4k-...-dual-audio/` | `12.4 GB` (1) | 1 | size assigned ✅ |
| `.../the-avengers-...-1080p-dublado-2012/` | `1.28 GB \| 2.34 GB` (2) | 3 | empty ❌ |

## Fix

Each download button is rendered right before its magnet as `SERVIDOR PARA DOWNLOAD BluRay 1080p (2.34 GB)`, so the size can be read per-magnet reliably. A new helper `findSizeNearMagnet` walks the magnet anchor's preceding siblings (stopping if it reaches another magnet, whose size belongs to it) and returns the closest size. `getTorrentsBluDV` now prefers this per-magnet size and falls back to the previous count-based mapping when none is found — so existing single-version behaviour is unchanged.

## Tests

- Added `Test_findSizeNearMagnet` covering the multi-version layout (two sized buttons + one without a size).
- `go build ./...`, `go vet ./api/` and `go test ./api/` all pass.
